### PR TITLE
[#17] Integrate survey list on Home screen

### DIFF
--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -3,6 +3,8 @@ import 'package:survey/api/service/survey_service.dart';
 import 'package:survey/database/hive_utils.dart';
 import 'package:survey/model/survey_model.dart';
 
+const _firstSurveysPageNumber = 1;
+
 abstract class SurveyRepository {
   Future<List<SurveyModel>> getSurveys({
     required int pageNumber,
@@ -26,12 +28,13 @@ class SurveyRepositoryImpl extends SurveyRepository {
     final surveyModels =
         response.surveys.map((item) => SurveyModel.fromResponse(item)).toList();
 
-    _saveSurveysCache(surveyModels);
+    _saveSurveysCache(pageNumber, surveyModels);
 
     return surveyModels;
   }
 
-  void _saveSurveysCache(List<SurveyModel> surveyModels) {
+  void _saveSurveysCache(int pageNumber, List<SurveyModel> surveyModels) {
+    if (pageNumber == _firstSurveysPageNumber) _hiveUtils.clearSurveys();
     _hiveUtils.saveSurveys(surveyModels);
   }
 }

--- a/lib/database/hive_utils.dart
+++ b/lib/database/hive_utils.dart
@@ -9,7 +9,7 @@ abstract class HiveUtils {
 
   void saveSurveys(List<SurveyModel> surveyModels);
 
-  void clear();
+  void clearSurveys();
 }
 
 @Singleton(as: HiveUtils)
@@ -30,7 +30,7 @@ class HiveUtilsImpl extends HiveUtils {
   }
 
   @override
-  void clear() async {
+  void clearSurveys() async {
     await _surveyBox.delete(_surveysKey);
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,6 +4,7 @@
     "loginForgotPassword": "Forgot?",
     "login": "Log In",
     "loginError": "Login failed, please recheck your email and password",
-    "invalidEmailPassword": "Invalid email or password",
-    "homeToday": "Today"
+    "loginInvalidEmailPassword": "Invalid email or password",
+    "homeToday": "Today",
+    "homeLoadSurveysError": "These are all surveys we can bring to you at the moment"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -4,6 +4,7 @@
     "loginForgotPassword": "ลืมรหัสผ่าน?",
     "login": "เข้าสู่ระบบ",
     "loginError": "เข้าสู่ระบบไม่สำเร็จ โปรดตรวจสอบอีเมลล์และรหัสผ่านอีกครั้ง",
-    "invalidEmailPassword": "อีเมลล์หรือรหัสผ่านไม่ถูกต้อง",
-    "homeToday": "วันนี้"
+    "loginInvalidEmailPassword": "อีเมลล์หรือรหัสผ่านไม่ถูกต้อง",
+    "homeToday": "วันนี้",
+    "homeLoadSurveysError": "นี่คือทั้งหมดที่เรานำมาให้คุณชมได้ในขณะนี้"
 }

--- a/lib/page/home/home_page.dart
+++ b/lib/page/home/home_page.dart
@@ -1,15 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey/di/di.dart';
 import 'package:survey/model/survey_model.dart';
 import 'package:survey/page/home/home_state.dart';
 import 'package:survey/page/home/home_view_model.dart';
 import 'package:survey/page/home/widget/home_header_widget.dart';
-import 'package:survey/page/home/widget/home_surveys_item_widget.dart';
+import 'package:survey/page/home/widget/home_surveys_page_view_widget.dart';
+import 'package:survey/usecase/get_cached_surveys_use_case.dart';
+import 'package:survey/usecase/get_surveys_use_case.dart';
 
 final homeViewModelProvider =
     StateNotifierProvider.autoDispose<HomeViewModel, HomeState>((ref) {
-  return HomeViewModel();
+  return HomeViewModel(
+    getIt.get<GetSurveysUseCase>(),
+    getIt.get<GetCachedSurveysUseCase>(),
+  );
 });
+
+final _surveysStreamProvider = StreamProvider.autoDispose<List<SurveyModel>>(
+    (ref) => ref.watch(homeViewModelProvider.notifier).surveys);
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -20,27 +30,58 @@ class HomePage extends ConsumerStatefulWidget {
 
 class _HomePageState extends ConsumerState<HomePage> {
   @override
+  void initState() {
+    super.initState();
+    ref.read(homeViewModelProvider.notifier).loadSurveysFromApi();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        // TODO: Integrate with real API
-        HomeSurveysItemWidget(
-          survey: SurveyModel(
-              id: "id",
-              title:
-                  "Career training and development Working from home Check-In",
-              description:
-                  "We would like to know what are your goals and skills you wanted. Building a workplace culture that prioritizes belonging and inclusion.",
-              coverImageUrl:
-                  "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l"),
-          onNextButtonPressed: () => {},
-        ),
-        SafeArea(
-          child: HomeHeaderWidget(
-              currentDate:
-                  ref.read(homeViewModelProvider.notifier).getCurrentDate()),
-        ),
-      ],
+    final surveys = ref.watch(_surveysStreamProvider).value ?? [];
+    return ref.watch(homeViewModelProvider).when(
+          init: () => _buildHomePage(surveys),
+          loading: () => _buildHomePage(surveys),
+          cacheLoadingSuccess: () => _buildHomePage(surveys),
+          apiLoadingSuccess: () =>
+              _buildHomePage(surveys, shouldEnablePagination: true),
+          error: (exception) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _showError(AppLocalizations.of(context)!.homeLoadSurveysError);
+            });
+            return _buildHomePage(surveys);
+          },
+        );
+  }
+
+  Widget _buildHomePage(
+    List<SurveyModel> surveys, {
+    bool shouldEnablePagination = false,
+  }) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: Stack(
+        children: [
+          HomeSurveysPageViewWidget(
+            surveys: surveys,
+            loadMoreSurveys: () => {
+              if (shouldEnablePagination)
+                ref.read(homeViewModelProvider.notifier).loadSurveysFromApi()
+            },
+          ),
+          SafeArea(
+            child: HomeHeaderWidget(
+                currentDate:
+                    ref.read(homeViewModelProvider.notifier).getCurrentDate()),
+          ),
+        ],
+      ),
     );
+  }
+
+  void _showError(String errorMessage) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      duration: const Duration(seconds: 2),
+      content: Text(errorMessage),
+    ));
   }
 }

--- a/lib/page/home/home_state.dart
+++ b/lib/page/home/home_state.dart
@@ -5,4 +5,12 @@ part 'home_state.freezed.dart';
 @freezed
 class HomeState with _$HomeState {
   const factory HomeState.init() = _Init;
+
+  const factory HomeState.loading() = _Loading;
+
+  const factory HomeState.cacheLoadingSuccess() = _CacheLoadingSuccess;
+
+  const factory HomeState.apiLoadingSuccess() = _ApiLoadingSuccess;
+
+  const factory HomeState.error(Exception error) = _Error;
 }

--- a/lib/page/home/home_view_model.dart
+++ b/lib/page/home/home_view_model.dart
@@ -1,13 +1,68 @@
 import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:rxdart/subjects.dart';
+import 'package:survey/model/survey_model.dart';
 import 'package:survey/page/home/home_state.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+import 'package:survey/usecase/get_cached_surveys_use_case.dart';
+import 'package:survey/usecase/get_surveys_use_case.dart';
 
-const String _homeCurrentDatePattern = 'EEEE, MMMM dd';
+const _homeCurrentDatePattern = 'EEEE, MMMM dd';
+const _surveysPageSize = 5;
 
 class HomeViewModel extends StateNotifier<HomeState> {
-  HomeViewModel() : super(const HomeState.init());
+  final GetSurveysUseCase _getSurveysUseCase;
+  final GetCachedSurveysUseCase _getCachedSurveysUseCase;
+
+  HomeViewModel(
+    this._getSurveysUseCase,
+    this._getCachedSurveysUseCase,
+  ) : super(const HomeState.init()) {
+    loadSurveysFromCache();
+  }
+
+  int _surveysPageNumber = 1;
+
+  final BehaviorSubject<List<SurveyModel>> _surveys = BehaviorSubject();
+
+  Stream<List<SurveyModel>> get surveys => _surveys.stream;
+
+  void loadSurveysFromCache() async {
+    final surveys = _getCachedSurveysUseCase.call();
+    if (surveys.isNotEmpty) {
+      _surveys.add(surveys);
+      state = const HomeState.cacheLoadingSuccess();
+    }
+  }
+
+  void loadSurveysFromApi() async {
+    final result = await _getSurveysUseCase.call(GetSurveysInput(
+      pageNumber: _surveysPageNumber,
+      pageSize: _surveysPageSize,
+    ));
+    if (result is Success<List<SurveyModel>>) {
+      final newSurveys = result.value;
+      if (_surveysPageNumber == 1) {
+        _surveys.add(newSurveys);
+      } else {
+        final currentSurveys = _surveys.value;
+        currentSurveys.addAll(newSurveys);
+        _surveys.add(currentSurveys);
+      }
+      state = const HomeState.apiLoadingSuccess();
+      _surveysPageNumber++;
+    } else {
+      state = HomeState.error((result as Failed).exception);
+    }
+  }
 
   String getCurrentDate() =>
       DateFormat(_homeCurrentDatePattern).format(clock.now()).toUpperCase();
+
+  @override
+  void dispose() async {
+    await _surveys.close();
+    super.dispose();
+  }
 }

--- a/lib/page/home/widget/home_surveys_page_view_widget.dart
+++ b/lib/page/home/widget/home_surveys_page_view_widget.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:survey/model/survey_model.dart';
+import 'package:survey/page/home/widget/home_surveys_item_widget.dart';
+
+class HomeSurveysPageViewWidget extends StatelessWidget {
+  final List<SurveyModel> surveys;
+  final VoidCallback loadMoreSurveys;
+  final _pageController = PageController();
+
+  HomeSurveysPageViewWidget({
+    required this.surveys,
+    required this.loadMoreSurveys,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView.builder(
+      itemCount: surveys.length,
+      controller: _pageController,
+      itemBuilder: (BuildContext context, int index) {
+        if (index + 1 == surveys.length) loadMoreSurveys.call();
+
+        return HomeSurveysItemWidget(
+          survey: surveys[index],
+          onNextButtonPressed: () => {
+            // TODO: Navigate to Survey Detail screen
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/page/login/login_page.dart
+++ b/lib/page/login/login_page.dart
@@ -35,7 +35,6 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
-    final loginViewModel = ref.watch(loginViewModelProvider);
     ref.listen<LoginState>(loginViewModelProvider, (
       LoginState? previousLoginState,
       LoginState newLoginState,
@@ -45,7 +44,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
         apiError: (error) =>
             _showError(AppLocalizations.of(context)!.loginError),
         invalidInputsError: () =>
-            _showError(AppLocalizations.of(context)!.invalidEmailPassword),
+            _showError(AppLocalizations.of(context)!.loginInvalidEmailPassword),
         orElse: () {},
       );
     });
@@ -113,10 +112,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
             ),
           ),
         ),
-        loginViewModel.maybeWhen(
-          loading: () => const CircularProgressBarWidget(),
-          orElse: () => const SizedBox(),
-        )
+        ref.watch(loginViewModelProvider).maybeWhen(
+              loading: () => const CircularProgressBarWidget(),
+              orElse: () => const SizedBox(),
+            )
       ],
     );
   }
@@ -128,7 +127,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
   void _showError(String errorMessage) {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      duration: const Duration(seconds: 1),
+      duration: const Duration(seconds: 2),
       content: Text(errorMessage),
     ));
   }

--- a/lib/resource/app_theme.dart
+++ b/lib/resource/app_theme.dart
@@ -6,6 +6,7 @@ class AppTheme {
   AppTheme._();
 
   static ThemeData get defaultTheme => ThemeData(
+        scaffoldBackgroundColor: Colors.black,
         fontFamily: FontFamily.neuzeit,
         textTheme: const TextTheme(
           bodyText1: TextStyle(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -602,6 +602,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.27.7"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   japx: ^2.0.4
   json_annotation: ^4.6.0
   retrofit: ^3.0.1+1
+  rxdart: ^0.27.7
   shared_preferences: ^2.0.15
 
 dev_dependencies:

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -35,7 +35,7 @@ void main() {
       expect(result.length, 2);
       expect(result[0].title, "Scarlett Bangkok");
       expect(result[1].title, "ibis Bangkok Riverside");
-
+      verify(mockHiveUtils.clearSurveys()).called(1);
       verify(mockHiveUtils.saveSurveys(result)).called(1);
     });
 

--- a/test/mock/mock_dependencies.dart
+++ b/test/mock/mock_dependencies.dart
@@ -6,6 +6,7 @@ import 'package:survey/api/service/auth_service.dart';
 import 'package:survey/api/service/survey_service.dart';
 import 'package:survey/database/hive_utils.dart';
 import 'package:survey/database/shared_preferences_utils.dart';
+import 'package:survey/usecase/get_cached_surveys_use_case.dart';
 import 'package:survey/usecase/get_surveys_use_case.dart';
 import 'package:survey/usecase/login_use_case.dart';
 
@@ -18,6 +19,7 @@ import 'package:survey/usecase/login_use_case.dart';
   MockSpec<SurveyService>(),
   MockSpec<LoginUseCase>(),
   MockSpec<GetSurveysUseCase>(),
+  MockSpec<GetCachedSurveysUseCase>(),
   MockSpec<DioError>(),
 ])
 void main() {}

--- a/test/page/home/home_view_model_test.dart
+++ b/test/page/home/home_view_model_test.dart
@@ -1,22 +1,95 @@
 import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/model/survey_model.dart';
 import 'package:survey/page/home/home_page.dart';
+import 'package:survey/page/home/home_state.dart';
 import 'package:survey/page/home/home_view_model.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+
+import '../../mock/mock_dependencies.mocks.dart';
 
 void main() {
   group('HomeViewModelTest', () {
+    late MockGetSurveysUseCase mockGetSurveysUseCase;
+    late MockGetCachedSurveysUseCase mockGetCachedSurveysUseCase;
     late ProviderContainer providerContainer;
     late HomeViewModel homeViewModel;
 
+    final List<SurveyModel> cachedSurveys = <SurveyModel>[
+      SurveyModel(
+        id: '1',
+        title: 'Title1',
+        description: 'Description1',
+        coverImageUrl: 'CoverImageUrl1',
+      )
+    ];
+    final List<SurveyModel> surveys = <SurveyModel>[
+      SurveyModel(
+        id: '2',
+        title: 'Title2',
+        description: 'Description2',
+        coverImageUrl: 'CoverImageUrl2',
+      ),
+    ];
+
     setUp(() {
+      mockGetSurveysUseCase = MockGetSurveysUseCase();
+      mockGetCachedSurveysUseCase = MockGetCachedSurveysUseCase();
+
+      when(mockGetCachedSurveysUseCase.call()).thenAnswer((_) => cachedSurveys);
+
       providerContainer = ProviderContainer(
         overrides: [
-          homeViewModelProvider.overrideWithValue(HomeViewModel()),
+          homeViewModelProvider.overrideWithValue(HomeViewModel(
+            mockGetSurveysUseCase,
+            mockGetCachedSurveysUseCase,
+          )),
         ],
       );
       addTearDown(providerContainer.dispose);
       homeViewModel = providerContainer.read(homeViewModelProvider.notifier);
+    });
+
+    test(
+        'When initializing, it fetches cached surveys correctly and returns CacheLoadingSuccess state',
+        () {
+      final surveysStream = homeViewModel.surveys;
+
+      expect(surveysStream, emitsInOrder([cachedSurveys]));
+      expect(
+        providerContainer.read(homeViewModelProvider),
+        const HomeState.cacheLoadingSuccess(),
+      );
+      verify(homeViewModel.loadSurveysFromCache()).called(1);
+    });
+
+    test(
+        'When loads surveys from api with Success result, it emits SurveyModel list and returns ApiLoadingSuccess state',
+        () async {
+      when(mockGetSurveysUseCase.call(any))
+          .thenAnswer((_) async => Success(surveys));
+      final surveysStream = homeViewModel.surveys;
+      final stateStream = homeViewModel.stream;
+
+      expect(surveysStream, emitsInOrder([cachedSurveys, surveys]));
+      expect(stateStream, emitsInOrder([HomeState.apiLoadingSuccess()]));
+
+      homeViewModel.loadSurveysFromApi();
+    });
+
+    test(
+        'When loads surveys from api with Failed result, it returns Error state',
+        () {
+      final exception = UseCaseException(Exception());
+      when(mockGetSurveysUseCase.call(any))
+          .thenAnswer((_) async => Failed(exception));
+      final stateStream = homeViewModel.stream;
+
+      expect(stateStream, emitsInOrder([HomeState.error(exception)]));
+
+      homeViewModel.loadSurveysFromApi();
     });
 
     test(

--- a/test/page/login/login_view_model_test.dart
+++ b/test/page/login/login_view_model_test.dart
@@ -12,9 +12,11 @@ void main() {
   group('LoginViewModelTest', () {
     late MockLoginUseCase mockLoginUseCase;
     late ProviderContainer providerContainer;
+    late LoginViewModel loginViewModel;
 
     setUp(() {
       mockLoginUseCase = MockLoginUseCase();
+
       providerContainer = ProviderContainer(
         overrides: [
           loginViewModelProvider
@@ -22,6 +24,7 @@ void main() {
         ],
       );
       addTearDown(providerContainer.dispose);
+      loginViewModel = providerContainer.read(loginViewModelProvider.notifier);
     });
 
     test('When initializing, it initializes with Init state', () {
@@ -34,8 +37,7 @@ void main() {
     test('When calling login with Success result, it returns Success state',
         () {
       when(mockLoginUseCase.call(any)).thenAnswer((_) async => Success(null));
-      final stateStream =
-          providerContainer.read(loginViewModelProvider.notifier).stream;
+      final stateStream = loginViewModel.stream;
 
       expect(
           stateStream,
@@ -43,16 +45,14 @@ void main() {
             const LoginState.loading(),
             const LoginState.success(),
           ]));
-      providerContainer
-          .read(loginViewModelProvider.notifier)
-          .login('chorny@berlento.com', '12345678');
+
+      loginViewModel.login('chorny@berlento.com', '12345678');
     });
 
     test(
         'When calling login with invalid email or password, it returns InvalidInputsError state',
         () {
-      final stateStream =
-          providerContainer.read(loginViewModelProvider.notifier).stream;
+      final stateStream = loginViewModel.stream;
 
       expect(
           stateStream,
@@ -60,9 +60,8 @@ void main() {
             const LoginState.loading(),
             const LoginState.invalidInputsError(),
           ]));
-      providerContainer
-          .read(loginViewModelProvider.notifier)
-          .login('Chorny', '');
+
+      loginViewModel.login('Chorny', '');
     });
 
     test('When calling login with Failed result, it returns ApiError state',
@@ -70,8 +69,7 @@ void main() {
       final exception = UseCaseException(Exception());
       when(mockLoginUseCase.call(any))
           .thenAnswer((_) async => Failed(exception));
-      final stateStream =
-          providerContainer.read(loginViewModelProvider.notifier).stream;
+      final stateStream = loginViewModel.stream;
 
       expect(
           stateStream,
@@ -79,9 +77,8 @@ void main() {
             const LoginState.loading(),
             LoginState.apiError(exception),
           ]));
-      providerContainer
-          .read(loginViewModelProvider.notifier)
-          .login('chorny@berlento.com', '12345678');
+
+      loginViewModel.login('chorny@berlento.com', '12345678');
     });
   });
 }


### PR DESCRIPTION
#17

## What happened 👀

Integrate the survey list on the Home screen

## Insight 📝

- [x] Display each survey on a `PageView` according to the design
- [x] Display cached survey list when entering the Home screen while loading the data from API
- [x] We will store the current survey list loading from the API as a cache
- [x] The survey list has pagination functionality: We will get 5 items from API each time. When entering the last item of the list, we will immediately load the following 5 items and attach them to the end of the current survey list (the pagination functionality only applies to the survey list loading from the API)
- [x] Show `Snackbar` when there's an error while loading the survey list
- [x] Add `rxdart` library
- [x] Add unit tests for `HomeViewModel` and refactor other test classes

## Proof Of Work 📹

https://user-images.githubusercontent.com/13492460/203574691-ccdc8c39-f083-4dbd-9ca0-ca0902403165.mp4
