### PR TITLE
[#69] Implement backend for getting user profile

### DIFF
--- a/lib/api/repository/user_repository.dart
+++ b/lib/api/repository/user_repository.dart
@@ -1,0 +1,20 @@
+import 'package:injectable/injectable.dart';
+import 'package:survey/api/service/user_service.dart';
+import 'package:survey/model/user_model.dart';
+
+abstract class UserRepository {
+  Future<UserModel> getUser();
+}
+
+@Singleton(as: UserRepository)
+class UserRepositoryImpl extends UserRepository {
+  final UserService _userService;
+
+  UserRepositoryImpl(this._userService);
+
+  @override
+  Future<UserModel> getUser() async {
+    final response = await _userService.getUser();
+    return UserModel.fromResponse(response);
+  }
+}

--- a/lib/api/response/user_response.dart
+++ b/lib/api/response/user_response.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:survey/api/response/converter/response_converter.dart';
+
+part 'user_response.g.dart';
+
+@JsonSerializable()
+class UserResponse {
+  final String id;
+  final String? email;
+  final String? name;
+  final String? avatarUrl;
+
+  UserResponse({
+    required this.id,
+    required this.email,
+    required this.name,
+    required this.avatarUrl,
+  });
+
+  factory UserResponse.fromJson(Map<String, dynamic> json) =>
+      _$UserResponseFromJson(fromDataJsonApi(json));
+}

--- a/lib/api/service/user_service.dart
+++ b/lib/api/service/user_service.dart
@@ -1,0 +1,13 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+import 'package:survey/api/response/user_response.dart';
+
+part 'user_service.g.dart';
+
+@RestApi()
+abstract class UserService {
+  factory UserService(Dio dio, {String baseUrl}) = _UserService;
+
+  @GET('/api/v1/me')
+  Future<UserResponse> getUser();
+}

--- a/lib/di/module/service_module.dart
+++ b/lib/di/module/service_module.dart
@@ -1,6 +1,7 @@
 import 'package:injectable/injectable.dart';
 import 'package:survey/api/service/auth_service.dart';
 import 'package:survey/api/service/survey_service.dart';
+import 'package:survey/api/service/user_service.dart';
 import 'package:survey/di/provider/dio_provider.dart';
 import 'package:survey/env_variables.dart';
 
@@ -17,6 +18,14 @@ abstract class ServiceModule {
   @Singleton()
   SurveyService provideSurveyService(DioProvider dioProvider) {
     return SurveyService(
+      dioProvider.getAuthenticatedDio(),
+      baseUrl: EnvVariables.apiEndpoint,
+    );
+  }
+
+  @Singleton()
+  UserService provideUserService(DioProvider dioProvider) {
+    return UserService(
       dioProvider.getAuthenticatedDio(),
       baseUrl: EnvVariables.apiEndpoint,
     );

--- a/lib/model/user_model.dart
+++ b/lib/model/user_model.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+import 'package:survey/api/response/user_response.dart';
+
+class UserModel extends Equatable {
+  final String name;
+  final String avatarUrl;
+
+  UserModel({
+    required this.name,
+    required this.avatarUrl,
+  });
+
+  @override
+  List<Object?> get props => [name, avatarUrl];
+
+  factory UserModel.fromResponse(UserResponse response) {
+    return UserModel(
+      name: response.name ?? "",
+      avatarUrl: response.avatarUrl ?? "",
+    );
+  }
+}

--- a/lib/usecase/base/base_use_case.dart
+++ b/lib/usecase/base/base_use_case.dart
@@ -10,6 +10,12 @@ abstract class UseCase<T, I> extends BaseUseCase<Result<T>> {
   Future<Result<T>> call(I input);
 }
 
+abstract class NoInputUseCase<T> extends BaseUseCase<Result<T>> {
+  const NoInputUseCase() : super();
+
+  Future<Result<T>> call();
+}
+
 abstract class SimpleUseCase<T> {
   const SimpleUseCase();
 

--- a/lib/usecase/get_user_use_case.dart
+++ b/lib/usecase/get_user_use_case.dart
@@ -1,0 +1,21 @@
+import 'package:injectable/injectable.dart';
+import 'package:survey/api/repository/user_repository.dart';
+import 'package:survey/model/user_model.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+
+@Injectable()
+class GetUserUseCase extends NoInputUseCase<UserModel> {
+  final UserRepository _repository;
+
+  const GetUserUseCase(this._repository);
+
+  @override
+  Future<Result<UserModel>> call() {
+    return _repository
+        .getUser()
+        // ignore: unnecessary_cast
+        .then((value) => Success(value) as Result<UserModel>)
+        .onError<Exception>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+}

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:survey/api/repository/survey_repository.dart';
 import 'package:survey/api/response/surveys_response.dart';
+import 'package:survey/model/survey_model.dart';
 
 import '../../mock/mock_dependencies.mocks.dart';
 import '../../utils/file_utils.dart';
@@ -27,14 +28,14 @@ void main() {
       final surveysJson =
           await FileUtils.loadFile('test/mock/mock_response/surveys.json');
       final response = SurveysResponse.fromJson(surveysJson);
-
       when(mockSurveyService.getSurveys(any, any))
           .thenAnswer((_) async => response);
+
       final result = await repository.getSurveys(pageNumber: 1, pageSize: 2);
 
       expect(result.length, 2);
-      expect(result[0].title, "Scarlett Bangkok");
-      expect(result[1].title, "ibis Bangkok Riverside");
+      expect(result[0], SurveyModel.fromResponse(response.surveys[0]));
+      expect(result[1], SurveyModel.fromResponse(response.surveys[1]));
       verify(mockHiveUtils.clearSurveys()).called(1);
       verify(mockHiveUtils.saveSurveys(result)).called(1);
     });

--- a/test/api/repository/user_repository_test.dart
+++ b/test/api/repository/user_repository_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/repository/user_repository.dart';
+import 'package:survey/api/response/user_response.dart';
+import 'package:survey/model/user_model.dart';
+
+import '../../mock/mock_dependencies.mocks.dart';
+import '../../utils/file_utils.dart';
+
+void main() {
+  group("UserRepositoryTest", () {
+    late MockUserService mockUserService;
+    late UserRepository repository;
+
+    setUp(() async {
+      mockUserService = MockUserService();
+      repository = UserRepositoryImpl(mockUserService);
+    });
+
+    test(
+        'When calling getUser successfully, it returns corresponding mapped result',
+        () async {
+      final userJson =
+          await FileUtils.loadFile('test/mock/mock_response/user.json');
+      final response = UserResponse.fromJson(userJson);
+
+      when(mockUserService.getUser()).thenAnswer((_) async => response);
+      final result = await repository.getUser();
+
+      expect(result, UserModel.fromResponse(response));
+    });
+
+    test('When calling getUser failed, it returns error', () async {
+      when(mockUserService.getUser()).thenThrow(MockDioError());
+
+      result() => repository.getUser();
+
+      expect(result, throwsA(isA<Exception>()));
+    });
+  });
+}

--- a/test/mock/mock_dependencies.dart
+++ b/test/mock/mock_dependencies.dart
@@ -2,24 +2,32 @@ import 'package:dio/dio.dart';
 import 'package:mockito/annotations.dart';
 import 'package:survey/api/repository/auth_repository.dart';
 import 'package:survey/api/repository/survey_repository.dart';
+import 'package:survey/api/repository/user_repository.dart';
 import 'package:survey/api/service/auth_service.dart';
 import 'package:survey/api/service/survey_service.dart';
+import 'package:survey/api/service/user_service.dart';
 import 'package:survey/database/hive_utils.dart';
 import 'package:survey/database/shared_preferences_utils.dart';
+import 'package:survey/model/user_model.dart';
 import 'package:survey/usecase/get_cached_surveys_use_case.dart';
 import 'package:survey/usecase/get_surveys_use_case.dart';
+import 'package:survey/usecase/get_user_use_case.dart';
 import 'package:survey/usecase/login_use_case.dart';
 
 @GenerateNiceMocks([
   MockSpec<AuthRepository>(),
   MockSpec<SurveyRepository>(),
+  MockSpec<UserRepository>(),
   MockSpec<SharedPreferencesUtils>(),
   MockSpec<HiveUtils>(),
   MockSpec<AuthService>(),
   MockSpec<SurveyService>(),
+  MockSpec<UserService>(),
   MockSpec<LoginUseCase>(),
   MockSpec<GetSurveysUseCase>(),
   MockSpec<GetCachedSurveysUseCase>(),
+  MockSpec<GetUserUseCase>(),
+  MockSpec<UserModel>(),
   MockSpec<DioError>(),
 ])
 void main() {}

--- a/test/mock/mock_response/user.json
+++ b/test/mock/mock_response/user.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "1",
+    "type": "user",
+    "attributes": {
+      "email": "chorny@berlento.com",
+      "name": "Chorn",
+      "avatar_url": "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
+    }
+  }
+}

--- a/test/usecase/get_user_use_case_test.dart
+++ b/test/usecase/get_user_use_case_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+import 'package:survey/usecase/get_user_use_case.dart';
+
+import '../../test/mock/mock_dependencies.mocks.dart';
+
+void main() {
+  group('GetUserUseCaseTest', () {
+    late MockUserRepository mockRepository;
+    late GetUserUseCase useCase;
+
+    setUp(() {
+      mockRepository = MockUserRepository();
+      useCase = GetUserUseCase(mockRepository);
+    });
+
+    test(
+        'When executing use case and repository returns success, it returns Success result with corresponding data',
+        () async {
+      final userModel = MockUserModel();
+      when(mockRepository.getUser()).thenAnswer((_) async => userModel);
+
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+      expect((result as Success).value, userModel);
+    });
+
+    test(
+        'When executing use case and repository returns error, it returns Failed result',
+        () async {
+      final exception = Exception();
+      when(mockRepository.getUser()).thenAnswer((_) => Future.error(exception));
+
+      final result = await useCase.call();
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}


### PR DESCRIPTION
#69

## What happened 👀

- Implement backend for getting user profile

## Insight 📝

- [x] Add `UserService`
- [x] Add `UserRepository` and corresponding unit tests
- [x] Add `GetUserUseCase` and corresponding unit tests
- [x] Add response and model class for mapping the user response from API

## Proof Of Work 📹

```
2022-11-29 08:42:06.076 17585-17687 flutter                 co.nimblehq.survey                   I  *** Request ***
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  uri: https://survey-api.nimblehq.co/api/v1/me
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  method: GET
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  responseType: ResponseType.json
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  followRedirects: true
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  connectTimeout: 30000
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  sendTimeout: 0
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  receiveTimeout: 30000
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  receiveDataWhenStatusError: true
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  extra: {}
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  headers:
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I   Authorization: Bearer mFm4X5immbOal1oaw1uUo2sbh7TBWxR523lxYI5np64
2022-11-29 08:42:06.077 17585-17687 flutter                 co.nimblehq.survey                   I  data:
2022-11-29 08:42:06.078 17585-17687 flutter                 co.nimblehq.survey                   I  {}
2022-11-29 08:42:06.078 17585-17687 flutter                 co.nimblehq.survey                   I  
2022-11-29 08:42:07.000 17585-17687 flutter                 co.nimblehq.survey                   I  *** Response ***
2022-11-29 08:42:07.000 17585-17687 flutter                 co.nimblehq.survey                   I  uri: https://survey-api.nimblehq.co/api/v1/me
2022-11-29 08:42:07.000 17585-17687 flutter                 co.nimblehq.survey                   I  statusCode: 200
2022-11-29 08:42:07.000 17585-17687 flutter                 co.nimblehq.survey                   I  headers:
2022-11-29 08:42:07.001 17585-17687 flutter                 co.nimblehq.survey                   I   connection: keep-alive
2022-11-29 08:42:07.001 17585-17687 flutter                 co.nimblehq.survey                   I   cache-control: max-age=0, private, must-revalidate
2022-11-29 08:42:07.001 17585-17687 flutter                 co.nimblehq.survey                   I   transfer-encoding: chunked
2022-11-29 08:42:07.001 17585-17687 flutter                 co.nimblehq.survey                   I   date: Tue, 29 Nov 2022 16:22:28 GMT
2022-11-29 08:42:07.001 17585-17687 flutter                 co.nimblehq.survey                   I   vary: Accept-Encoding, Origin
2022-11-29 08:42:07.002 17585-17687 flutter                 co.nimblehq.survey                   I   content-encoding: gzip
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   strict-transport-security: max-age=31536000; includeSubDomains
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   referrer-policy: strict-origin-when-cross-origin
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=wEniy1JuXrnMKV%2BdVmmfh79679VvSmVuPSdilDlTCmhb6KD30bPCNKS282CGm4r%2F46%2B1WqrUR%2F6fTqrfflulOfFQ4jaOJ4ijmN5LgpsFBc8Wvic6zsip65vIts280GrPGXN%2FnU3J5%2Fog"}],"group":"cf-nel","max_age":604800}
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   cf-cache-status: DYNAMIC
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   x-permitted-cross-domain-policies: none
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   content-type: application/json; charset=utf-8
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   x-xss-protection: 1; mode=block
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   server: cloudflare
2022-11-29 08:42:07.003 17585-17687 flutter                 co.nimblehq.survey                   I   x-request-id: 7b8f251b-55be-40f4-9442-288513213f1b
2022-11-29 08:42:07.004 17585-17687 flutter                 co.nimblehq.survey                   I   alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
2022-11-29 08:42:07.004 17585-17687 flutter                 co.nimblehq.survey                   I   nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
2022-11-29 08:42:07.004 17585-17687 flutter                 co.nimblehq.survey                   I   x-download-options: noopen
2022-11-29 08:42:07.004 17585-17687 flutter                 co.nimblehq.survey                   I   cf-ray: 771caea6bbf4ee62-BKK
2022-11-29 08:42:07.004 17585-17687 flutter                 co.nimblehq.survey                   I   x-runtime: 0.006531
2022-11-29 08:42:07.004 17585-17687 flutter                 co.nimblehq.survey                   I   etag: W/"369e0bcfaa8b8b4febafbd890e2535b3"
2022-11-29 08:42:07.004 17585-17687 flutter                 co.nimblehq.survey                   I   via: 1.1 vegur
2022-11-29 08:42:07.005 17585-17687 flutter                 co.nimblehq.survey                   I   x-frame-options: SAMEORIGIN
2022-11-29 08:42:07.005 17585-17687 flutter                 co.nimblehq.survey                   I   x-content-type-options: nosniff
2022-11-29 08:42:07.005 17585-17687 flutter                 co.nimblehq.survey                   I  Response Text:
2022-11-29 08:42:07.005 17585-17687 flutter                 co.nimblehq.survey                   I  {"data":{"id":"167","type":"user","attributes":{"email":"kaung@nimblehq.co","name":"Kaung","avatar_url":"https://secure.gravatar.com/avatar/907e92907b23c1dbca189496c59aed20"}}}
2022-11-29 08:42:07.005 17585-17687 flutter                 co.nimblehq.survey                   I  
```