### PR TITLE
[#20] Implement pull to refresh surveys on Home screen

### DIFF
--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -1,10 +1,9 @@
 import 'package:injectable/injectable.dart';
 import 'package:survey/api/exception/network_exceptions.dart';
 import 'package:survey/api/service/survey_service.dart';
+import 'package:survey/constants.dart';
 import 'package:survey/database/hive_utils.dart';
 import 'package:survey/model/survey_model.dart';
-
-const _firstSurveysPageNumber = 1;
 
 abstract class SurveyRepository {
   Future<List<SurveyModel>> getSurveys({
@@ -40,7 +39,9 @@ class SurveyRepositoryImpl extends SurveyRepository {
   }
 
   void _saveSurveysCache(int pageNumber, List<SurveyModel> surveyModels) {
-    if (pageNumber == _firstSurveysPageNumber) _hiveUtils.clearSurveys();
+    if (pageNumber == Constants.firstSurveysPageNumber) {
+      _hiveUtils.clearSurveys();
+    }
     _hiveUtils.saveSurveys(surveyModels);
   }
 }

--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -30,7 +30,8 @@ class SurveyRepositoryImpl extends SurveyRepository {
           .map((item) => SurveyModel.fromResponse(item))
           .toList();
 
-      _saveSurveysCache(pageNumber, surveyModels);
+      final shouldClearCache = pageNumber == Constants.firstSurveysPageNumber;
+      _saveSurveysCache(shouldClearCache, surveyModels);
 
       return surveyModels;
     } catch (exception) {
@@ -38,10 +39,11 @@ class SurveyRepositoryImpl extends SurveyRepository {
     }
   }
 
-  void _saveSurveysCache(int pageNumber, List<SurveyModel> surveyModels) {
-    if (pageNumber == Constants.firstSurveysPageNumber) {
-      _hiveUtils.clearSurveys();
-    }
+  void _saveSurveysCache(
+    bool shouldClearCache,
+    List<SurveyModel> surveyModels,
+  ) {
+    if (shouldClearCache) _hiveUtils.clearSurveys();
     _hiveUtils.saveSurveys(surveyModels);
   }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,4 +2,5 @@ class Constants {
   Constants._();
 
   static const int snackBarDurationInSecond = 2;
+  static const int firstSurveysPageNumber = 1;
 }

--- a/lib/page/home/home_page.dart
+++ b/lib/page/home/home_page.dart
@@ -32,6 +32,9 @@ final _userStreamProvider = StreamProvider.autoDispose<UserModel>(
 final _errorStreamProvider = StreamProvider.autoDispose<String>(
     (ref) => ref.watch(homeViewModelProvider.notifier).error);
 
+final jumpToFirstSurveysPageStreamProvider = StreamProvider.autoDispose<void>(
+    (ref) => ref.watch(homeViewModelProvider.notifier).jumpToFirstSurveysPage);
+
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
 
@@ -58,11 +61,20 @@ class _HomePageState extends ConsumerState<HomePage> {
     final surveys = ref.watch(_surveysStreamProvider).value ?? [];
     return ref.watch(homeViewModelProvider).when(
           init: () => HomeSkeletonLoadingWidget(),
-          loading: () => _buildHomePage(surveys, shouldShowLoading: true),
+          loading: () => _buildHomePage(
+            surveys,
+            shouldShowLoading: true,
+          ),
           cacheLoadingSuccess: () => _buildHomePage(surveys),
-          apiLoadingSuccess: () =>
-              _buildHomePage(surveys, shouldEnablePagination: true),
-          loadSurveysError: () => _buildHomePage(surveys),
+          apiLoadingSuccess: () => _buildHomePage(
+            surveys,
+            shouldEnablePagination: true,
+            shouldEnablePullToRefresh: true,
+          ),
+          loadSurveysError: () => _buildHomePage(
+            surveys,
+            shouldEnablePullToRefresh: true,
+          ),
         );
   }
 
@@ -70,37 +82,52 @@ class _HomePageState extends ConsumerState<HomePage> {
     List<SurveyModel> surveys, {
     bool shouldShowLoading = false,
     bool shouldEnablePagination = false,
+    bool shouldEnablePullToRefresh = false,
   }) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      body: Stack(
-        children: [
-          if (surveys.isNotEmpty) ...[
-            HomeSurveysPageViewWidget(
-              surveys: surveys,
-              loadMoreSurveys: () => {
-                if (shouldEnablePagination)
-                  ref.read(homeViewModelProvider.notifier).loadSurveysFromApi()
-              },
-              currentSurveysPage: _currentSurveysPage,
+      body: RefreshIndicator(
+        color: Colors.white,
+        backgroundColor: Colors.white30,
+        onRefresh: () =>
+            ref.read(homeViewModelProvider.notifier).refreshSurveys(),
+        child: Stack(
+          children: [
+            if (surveys.isNotEmpty) ...[
+              HomeSurveysPageViewWidget(
+                surveys: surveys,
+                loadMoreSurveys: () => {
+                  if (shouldEnablePagination)
+                    ref
+                        .read(homeViewModelProvider.notifier)
+                        .loadSurveysFromApi()
+                },
+                currentSurveysPage: _currentSurveysPage,
+              ),
+              HomeSurveysIndicatorsWidget(
+                surveysLength: surveys.length,
+                currentSurveysPage: _currentSurveysPage,
+              ),
+            ],
+            // Workaround to allow the page to be scrolled vertically to refresh on top
+            if (shouldEnablePullToRefresh)
+              FractionallySizedBox(
+                heightFactor: 0.3,
+                child: ListView(),
+              ),
+            SafeArea(
+              child: HomeHeaderWidget(
+                currentDate:
+                    ref.read(homeViewModelProvider.notifier).getCurrentDate(),
+                userAvatarUrl: ref.watch(_userStreamProvider).value?.avatarUrl,
+              ),
             ),
-            HomeSurveysIndicatorsWidget(
-              surveysLength: surveys.length,
-              currentSurveysPage: _currentSurveysPage,
-            ),
+            if (shouldShowLoading)
+              const Center(
+                child: CircularProgressIndicator(color: Colors.white),
+              )
           ],
-          SafeArea(
-            child: HomeHeaderWidget(
-              currentDate:
-                  ref.read(homeViewModelProvider.notifier).getCurrentDate(),
-              userAvatarUrl: ref.watch(_userStreamProvider).value?.avatarUrl,
-            ),
-          ),
-          if (shouldShowLoading)
-            const Center(
-              child: CircularProgressIndicator(color: Colors.white),
-            )
-        ],
+        ),
       ),
     );
   }

--- a/lib/page/home/widget/home_surveys_page_view_widget.dart
+++ b/lib/page/home/widget/home_surveys_page_view_widget.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:survey/model/survey_model.dart';
+import 'package:survey/page/home/home_page.dart';
 import 'package:survey/page/home/widget/home_surveys_item_widget.dart';
 
-class HomeSurveysPageViewWidget extends StatelessWidget {
+class HomeSurveysPageViewWidget extends ConsumerWidget {
   final List<SurveyModel> surveys;
   final VoidCallback loadMoreSurveys;
   final ValueNotifier<int> currentSurveysPage;
@@ -15,7 +17,12 @@ class HomeSurveysPageViewWidget extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue<void>>(jumpToFirstSurveysPageStreamProvider,
+        (oldValue, newValue) {
+      _pageController.jumpToPage(0);
+    });
+
     if (currentSurveysPage.value > surveys.length - 1) {
       currentSurveysPage.value = surveys.length - 1;
     }

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -24,7 +24,7 @@ void main() {
     });
 
     test(
-        'When calling getSurveys with pageNumber equal to 1 successfully, it returns corresponding mapped result and clear surveys cache',
+        'When calling getSurveys on the first page successfully, it returns corresponding mapped result and clear surveys cache',
         () async {
       final surveysJson =
           await FileUtils.loadFile('test/mock/mock_response/surveys.json');
@@ -42,7 +42,7 @@ void main() {
     });
 
     test(
-        'When calling getSurveys with pageNumber not equal to 1 successfully, it returns corresponding mapped result',
+        'When calling getSurveys not on the first page successfully, it returns corresponding mapped result',
         () async {
       final surveysJson =
           await FileUtils.loadFile('test/mock/mock_response/surveys.json');

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -24,7 +24,7 @@ void main() {
     });
 
     test(
-        'When calling getSurveys successfully, it returns corresponding mapped result',
+        'When calling getSurveys with pageNumber equal to 1 successfully, it returns corresponding mapped result and clear surveys cache',
         () async {
       final surveysJson =
           await FileUtils.loadFile('test/mock/mock_response/surveys.json');
@@ -38,6 +38,23 @@ void main() {
       expect(result[0], SurveyModel.fromResponse(response.surveys[0]));
       expect(result[1], SurveyModel.fromResponse(response.surveys[1]));
       verify(mockHiveUtils.clearSurveys()).called(1);
+      verify(mockHiveUtils.saveSurveys(result)).called(1);
+    });
+
+    test(
+        'When calling getSurveys with pageNumber not equal to 1 successfully, it returns corresponding mapped result',
+        () async {
+      final surveysJson =
+          await FileUtils.loadFile('test/mock/mock_response/surveys.json');
+      final response = SurveysResponse.fromJson(surveysJson);
+      when(mockSurveyService.getSurveys(any, any))
+          .thenAnswer((_) async => response);
+
+      final result = await repository.getSurveys(pageNumber: 2, pageSize: 2);
+
+      expect(result.length, 2);
+      expect(result[0], SurveyModel.fromResponse(response.surveys[0]));
+      expect(result[1], SurveyModel.fromResponse(response.surveys[1]));
       verify(mockHiveUtils.saveSurveys(result)).called(1);
     });
 

--- a/test/page/home/home_view_model_test.dart
+++ b/test/page/home/home_view_model_test.dart
@@ -134,6 +134,38 @@ void main() {
     });
 
     test(
+        'When refreshing surveys with Success result, it emits SurveyModel list and returns ApiLoadingSuccess state',
+        () async {
+      when(mockGetSurveysUseCase.call(any))
+          .thenAnswer((_) async => Success(surveys));
+      final surveysStream = homeViewModel.surveys;
+      final stateStream = homeViewModel.stream;
+
+      expect(surveysStream, emitsInOrder([surveys]));
+      expect(stateStream, emitsInOrder([const HomeState.apiLoadingSuccess()]));
+
+      homeViewModel.refreshSurveys();
+    });
+
+    test(
+        'When refreshing surveys with Failed result, it returns LoadSurveysError state and emits corresponding errorMessage',
+        () {
+      when(mockGetSurveysUseCase.call(any))
+          .thenAnswer((_) async => Failed(mockException));
+      final errorStream = homeViewModel.error;
+      final stateStream = homeViewModel.stream;
+
+      expect(
+          errorStream,
+          emitsInOrder([
+            NetworkExceptions.getErrorMessage(NetworkExceptions.badRequest())
+          ]));
+      expect(stateStream, emitsInOrder([const HomeState.loadSurveysError()]));
+
+      homeViewModel.refreshSurveys();
+    });
+
+    test(
         'When getting current date, it returns formatted current date correctly',
         () {
       withClock(Clock.fixed(DateTime(2000)), () {


### PR DESCRIPTION
#20 

## What happened 👀

- [x] Add a refresh indicator for refreshing survey list on the Home screen using Lucus's workaround
- [x] Always jump to the first page when executing pull to refresh
- [x] When refreshing the survey list, refresh all loaded survey items
- [x] Pull to refresh functionality will only be enabled when the Home screen's state is `ApiLoadingSuccess` or `Error` (after finish loading survey list from the API)
- [x] Move a constant to a common `Constants` class
- [x] Add unit tests for `refreshSurveys` function

## Insight 📝

N/A

## Proof Of Work 📹

https://user-images.githubusercontent.com/13492460/205985059-333546c0-0ff3-417f-93db-8cd9f81eda6f.mp4
