### PR TITLE
[#9] Implement backend for Reset Password screen

### DIFF
--- a/lib/api/repository/auth_repository.dart
+++ b/lib/api/repository/auth_repository.dart
@@ -2,6 +2,7 @@ import 'package:injectable/injectable.dart';
 import 'package:survey/api/exception/network_exceptions.dart';
 import 'package:survey/api/grant_type.dart';
 import 'package:survey/api/request/login_request.dart';
+import 'package:survey/api/request/reset_password_request.dart';
 import 'package:survey/api/service/auth_service.dart';
 import 'package:survey/env_variables.dart';
 import 'package:survey/model/login_model.dart';
@@ -10,6 +11,10 @@ abstract class AuthRepository {
   Future<LoginModel> login({
     required String email,
     required String password,
+  });
+
+  Future<void> resetPassword({
+    required String email,
   });
 }
 
@@ -35,6 +40,21 @@ class AuthRepositoryImpl extends AuthRepository {
         ),
       );
       return LoginModel.fromResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<void> resetPassword({required String email}) async {
+    try {
+      await _authService.resetPassword(
+        ResetPasswordRequest(
+          user: ResetPasswordUserRequest(email: email),
+          clientId: EnvVariables.clientId,
+          clientSecret: EnvVariables.clientSecret,
+        ),
+      );
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/request/reset_password_request.dart
+++ b/lib/api/request/reset_password_request.dart
@@ -1,0 +1,35 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'reset_password_request.g.dart';
+
+@JsonSerializable()
+class ResetPasswordRequest {
+  final ResetPasswordUserRequest user;
+  final String clientId;
+  final String clientSecret;
+
+  ResetPasswordRequest({
+    required this.user,
+    required this.clientId,
+    required this.clientSecret,
+  });
+
+  factory ResetPasswordRequest.fromJson(Map<String, dynamic> json) =>
+      _$ResetPasswordRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ResetPasswordRequestToJson(this);
+}
+
+@JsonSerializable()
+class ResetPasswordUserRequest {
+  final String email;
+
+  ResetPasswordUserRequest({
+    required this.email,
+  });
+
+  factory ResetPasswordUserRequest.fromJson(Map<String, dynamic> json) =>
+      _$ResetPasswordUserRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ResetPasswordUserRequestToJson(this);
+}

--- a/lib/api/service/auth_service.dart
+++ b/lib/api/service/auth_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:survey/api/request/login_request.dart';
+import 'package:survey/api/request/reset_password_request.dart';
 import 'package:survey/api/response/login_response.dart';
 
 part 'auth_service.g.dart';
@@ -12,5 +13,10 @@ abstract class AuthService {
   @POST('/api/v1/oauth/token')
   Future<LoginResponse> login(
     @Body() LoginRequest body,
+  );
+
+  @POST('/api/v1/passwords')
+  Future<void> resetPassword(
+    @Body() ResetPasswordRequest body,
   );
 }

--- a/lib/usecase/reset_password_use_case.dart
+++ b/lib/usecase/reset_password_use_case.dart
@@ -1,0 +1,21 @@
+import 'package:injectable/injectable.dart';
+import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/api/repository/auth_repository.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+
+@Injectable()
+class ResetPasswordUseCase extends UseCase<void, String> {
+  final AuthRepository _repository;
+
+  const ResetPasswordUseCase(this._repository);
+
+  @override
+  Future<Result<void>> call(String email) {
+    return _repository
+        .resetPassword(email: email)
+        // ignore: unnecessary_cast
+        .then((value) => Success(null) as Result<void>)
+        .onError<NetworkExceptions>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+}

--- a/test/api/repository/auth_repository_test.dart
+++ b/test/api/repository/auth_repository_test.dart
@@ -41,8 +41,8 @@ void main() {
       when(mockAuthService.login(any)).thenAnswer((_) async => response);
 
       final result = await repository.login(
-        email: "email",
-        password: "password",
+        email: 'email',
+        password: 'password',
       );
 
       expect(result, expected);
@@ -52,7 +52,24 @@ void main() {
         () async {
       when(mockAuthService.login(any)).thenThrow(MockDioError());
 
-      result() => repository.login(email: "email", password: "password");
+      result() => repository.login(email: 'email', password: 'password');
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+
+    test('When calling reset password successfully, it returns empty result',
+        () async {
+      when(mockAuthService.resetPassword(any)).thenAnswer((_) async => null);
+
+      await repository.resetPassword(email: 'email');
+    });
+
+    test(
+        'When calling reset password failed, it returns NetworkExceptions error',
+        () async {
+      when(mockAuthService.resetPassword(any)).thenThrow(MockDioError());
+
+      result() => repository.resetPassword(email: 'email');
 
       expect(result, throwsA(isA<NetworkExceptions>()));
     });

--- a/test/usecase/reset_password_use_case_test.dart
+++ b/test/usecase/reset_password_use_case_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+import 'package:survey/usecase/reset_password_use_case.dart';
+
+import '../../test/mock/mock_dependencies.mocks.dart';
+
+void main() {
+  group('ResetPasswordUseCaseTest', () {
+    late MockAuthRepository mockRepository;
+    late ResetPasswordUseCase useCase;
+
+    final email = 'chorny@berlento.com';
+
+    setUp(() {
+      mockRepository = MockAuthRepository();
+      useCase = ResetPasswordUseCase(mockRepository);
+    });
+
+    test(
+        'When executing use case and repository returns success, it returns Success result',
+        () async {
+      when(mockRepository.resetPassword(email: email))
+          .thenAnswer((_) async => null);
+
+      final result = await useCase.call(email);
+
+      expect(result, isA<Success>());
+    });
+
+    test(
+        'When executing use case and repository returns error, it returns Failed result',
+        () async {
+      final exception = NetworkExceptions.badRequest();
+      when(mockRepository.resetPassword(email: email))
+          .thenAnswer((_) => Future.error(exception));
+
+      final result = await useCase.call(email);
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}


### PR DESCRIPTION
#9

## What happened 👀

- [x] Add reset password API call on `AuthService`
- [x] Add reset password function on `AuthRepository` and add corresponding unit tests
- [x] Create `ResetPasswordUseCase` and add corresponding unit tests
- [x] Create `ResetPasswordRequest`

## Insight 📝

N/A

## Proof Of Work 📹

```
2022-12-12 18:34:08.128 20061-20089 flutter                 co.nimblehq.survey                   I  *** Request ***
2022-12-12 18:34:08.130 20061-20089 flutter                 co.nimblehq.survey                   I  uri: https://survey-api.nimblehq.co/api/v1/passwords
2022-12-12 18:34:08.130 20061-20089 flutter                 co.nimblehq.survey                   I  method: POST
2022-12-12 18:34:08.132 20061-20089 flutter                 co.nimblehq.survey                   I  responseType: ResponseType.json
2022-12-12 18:34:08.134 20061-20089 flutter                 co.nimblehq.survey                   I  followRedirects: true
2022-12-12 18:34:08.134 20061-20089 flutter                 co.nimblehq.survey                   I  connectTimeout: 30000
2022-12-12 18:34:08.134 20061-20089 flutter                 co.nimblehq.survey                   I  sendTimeout: 0
2022-12-12 18:34:08.134 20061-20089 flutter                 co.nimblehq.survey                   I  receiveTimeout: 30000
2022-12-12 18:34:08.135 20061-20089 flutter                 co.nimblehq.survey                   I  receiveDataWhenStatusError: true
2022-12-12 18:34:08.135 20061-20089 flutter                 co.nimblehq.survey                   I  extra: {}
2022-12-12 18:34:08.135 20061-20089 flutter                 co.nimblehq.survey                   I  headers:
2022-12-12 18:34:08.135 20061-20089 flutter                 co.nimblehq.survey                   I   content-type: application/json; charset=utf-8
2022-12-12 18:34:08.136 20061-20089 flutter                 co.nimblehq.survey                   I  data:
2022-12-12 18:34:08.136 20061-20089 flutter                 co.nimblehq.survey                   I  {user: Instance of 'ResetPasswordUserRequest', client_id: 4gg3bokkvPnMxWz7HHTdM_wf1RNg9k8iA6sZ2ZrA7EA, client_secret: y_GgV-GEjWd3VTzbZBS6tqEco0E68QuqHQv0QND2vKo}
2022-12-12 18:34:08.136 20061-20089 flutter                 co.nimblehq.survey                   I  
2022-12-12 18:34:09.163 20061-20089 flutter                 co.nimblehq.survey                   I  *** Response ***
2022-12-12 18:34:09.164 20061-20089 flutter                 co.nimblehq.survey                   I  uri: https://survey-api.nimblehq.co/api/v1/passwords
2022-12-12 18:34:09.164 20061-20089 flutter                 co.nimblehq.survey                   I  statusCode: 200
2022-12-12 18:34:09.164 20061-20089 flutter                 co.nimblehq.survey                   I  headers:
2022-12-12 18:34:09.164 20061-20089 flutter                 co.nimblehq.survey                   I   connection: keep-alive
2022-12-12 18:34:09.164 20061-20089 flutter                 co.nimblehq.survey                   I   cache-control: max-age=0, private, must-revalidate
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   transfer-encoding: chunked
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   date: Mon, 12 Dec 2022 11:34:09 GMT
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   vary: Accept-Encoding, Origin
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   content-encoding: gzip
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   strict-transport-security: max-age=31536000; includeSubDomains
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   referrer-policy: strict-origin-when-cross-origin
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=jCOuZQ6mf5wEODJukkOGqCzt9Bg74PW6TYFOxvobk7LO6q%2FiBeik7ufyr6QdSf0X1zY6EG4GO8OyXzww4CG6uXYhDxp1n83QTdUdB7U3FjPB6nUOT6w4CSnz2tIS0MDfRVY3YYMER7lF"}],"group":"cf-nel","max_age":604800}
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   cf-cache-status: DYNAMIC
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   x-permitted-cross-domain-policies: none
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   content-type: application/json; charset=utf-8
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   x-xss-protection: 1; mode=block
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   server: cloudflare
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   x-request-id: 3ac7fd2f-07b2-40ed-bb9a-29664cda0a51
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   x-download-options: noopen
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   cf-ray: 7786262e7fe7ee56-BKK
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   x-runtime: 0.009230
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   etag: W/"2fd772537cd5354bbe064e0f71a09920"
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   via: 1.1 vegur
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   x-frame-options: SAMEORIGIN
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I   x-content-type-options: nosniff
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I  Response Text:
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I  {"meta":{"message":"If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."}}
2022-12-12 18:34:09.165 20061-20089 flutter                 co.nimblehq.survey                   I  
```