### PR TITLE
[#15] Implement backend for logout functionality

### DIFF
--- a/lib/api/repository/auth_repository.dart
+++ b/lib/api/repository/auth_repository.dart
@@ -2,6 +2,7 @@ import 'package:injectable/injectable.dart';
 import 'package:survey/api/exception/network_exceptions.dart';
 import 'package:survey/api/grant_type.dart';
 import 'package:survey/api/request/login_request.dart';
+import 'package:survey/api/request/logout_request.dart';
 import 'package:survey/api/request/reset_password_request.dart';
 import 'package:survey/api/service/auth_service.dart';
 import 'package:survey/env_variables.dart';
@@ -11,6 +12,10 @@ abstract class AuthRepository {
   Future<LoginModel> login({
     required String email,
     required String password,
+  });
+
+  Future<void> logout({
+    required String token,
   });
 
   Future<void> resetPassword({
@@ -40,6 +45,21 @@ class AuthRepositoryImpl extends AuthRepository {
         ),
       );
       return LoginModel.fromResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<void> logout({required String token}) async {
+    try {
+      await _authService.logout(
+        LogoutRequest(
+          token: token,
+          clientId: EnvVariables.clientId,
+          clientSecret: EnvVariables.clientSecret,
+        ),
+      );
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/request/logout_request.dart
+++ b/lib/api/request/logout_request.dart
@@ -1,0 +1,21 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'logout_request.g.dart';
+
+@JsonSerializable()
+class LogoutRequest {
+  final String token;
+  final String clientId;
+  final String clientSecret;
+
+  LogoutRequest({
+    required this.token,
+    required this.clientId,
+    required this.clientSecret,
+  });
+
+  factory LogoutRequest.fromJson(Map<String, dynamic> json) =>
+      _$LogoutRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LogoutRequestToJson(this);
+}

--- a/lib/api/service/auth_service.dart
+++ b/lib/api/service/auth_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:survey/api/request/login_request.dart';
+import 'package:survey/api/request/logout_request.dart';
 import 'package:survey/api/request/reset_password_request.dart';
 import 'package:survey/api/response/login_response.dart';
 
@@ -13,6 +14,11 @@ abstract class AuthService {
   @POST('/api/v1/oauth/token')
   Future<LoginResponse> login(
     @Body() LoginRequest body,
+  );
+
+  @POST('/api/v1/oauth/revoke')
+  Future<void> logout(
+    @Body() LogoutRequest body,
   );
 
   @POST('/api/v1/passwords')

--- a/lib/database/shared_preferences_utils.dart
+++ b/lib/database/shared_preferences_utils.dart
@@ -19,6 +19,8 @@ abstract class SharedPreferencesUtils {
   void saveTokenType(String tokenType);
 
   void saveRefreshToken(String refreshToken);
+
+  void clear();
 }
 
 @Singleton(as: SharedPreferencesUtils)
@@ -53,5 +55,10 @@ class SharedPreferencesUtilsImpl extends SharedPreferencesUtils {
   @override
   void saveRefreshToken(String refreshToken) async {
     await _sharedPreferences.setString(_refreshTokenKey, refreshToken);
+  }
+
+  @override
+  void clear() async {
+    await _sharedPreferences.clear();
   }
 }

--- a/lib/usecase/logout_use_case.dart
+++ b/lib/usecase/logout_use_case.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:injectable/injectable.dart';
+import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/api/repository/auth_repository.dart';
+import 'package:survey/database/hive_utils.dart';
+import 'package:survey/database/shared_preferences_utils.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+
+@Injectable()
+class LogoutUseCase extends NoInputUseCase<void> {
+  final AuthRepository _repository;
+  final SharedPreferencesUtils _sharedPreferencesUtils;
+  final HiveUtils _hiveUtils;
+
+  const LogoutUseCase(
+    this._repository,
+    this._sharedPreferencesUtils,
+    this._hiveUtils,
+  );
+
+  @override
+  Future<Result<void>> call() async {
+    final token = await _sharedPreferencesUtils.accessToken;
+    return _repository
+        .logout(token: token)
+        .then((value) => _clearTokensAndCache())
+        .onError<NetworkExceptions>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+
+  Result<void> _clearTokensAndCache() {
+    _sharedPreferencesUtils.clear();
+    _hiveUtils.clearSurveys();
+    return Success(null);
+  }
+}

--- a/test/api/repository/auth_repository_test.dart
+++ b/test/api/repository/auth_repository_test.dart
@@ -57,6 +57,21 @@ void main() {
       expect(result, throwsA(isA<NetworkExceptions>()));
     });
 
+    test('When calling logout successfully, it returns empty result', () async {
+      when(mockAuthService.logout(any)).thenAnswer((_) async => null);
+
+      await repository.logout(token: 'token');
+    });
+
+    test('When calling logout failed, it returns NetworkExceptions error',
+        () async {
+      when(mockAuthService.logout(any)).thenThrow(MockDioError());
+
+      result() => repository.logout(token: 'token');
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+
     test('When calling reset password successfully, it returns empty result',
         () async {
       when(mockAuthService.resetPassword(any)).thenAnswer((_) async => null);

--- a/test/usecase/logout_use_case_test.dart
+++ b/test/usecase/logout_use_case_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+import 'package:survey/usecase/logout_use_case.dart';
+
+import '../../test/mock/mock_dependencies.mocks.dart';
+
+void main() {
+  group('LogoutUseCaseTest', () {
+    late MockAuthRepository mockRepository;
+    late MockSharedPreferencesUtils mockSharedPreferencesUtils;
+    late MockHiveUtils mockHiveUtils;
+    late LogoutUseCase useCase;
+
+    setUp(() {
+      mockRepository = MockAuthRepository();
+      mockSharedPreferencesUtils = MockSharedPreferencesUtils();
+      mockHiveUtils = MockHiveUtils();
+      useCase = LogoutUseCase(
+        mockRepository,
+        mockSharedPreferencesUtils,
+        mockHiveUtils,
+      );
+    });
+
+    test(
+        'When executing use case and repository returns success, it returns Success result',
+        () async {
+      when(mockRepository.logout(token: anyNamed('token')))
+          .thenAnswer((_) async => null);
+
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+      verify(mockSharedPreferencesUtils.clear()).called(1);
+      verify(mockHiveUtils.clearSurveys()).called(1);
+    });
+
+    test(
+        'When executing use case and repository returns error, it returns Failed result',
+        () async {
+      final exception = NetworkExceptions.badRequest();
+      when(mockRepository.logout(token: anyNamed('token')))
+          .thenAnswer((_) => Future.error(exception));
+
+      final result = await useCase.call();
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}


### PR DESCRIPTION
#15

## What happened 👀

- [x] Create `LogoutRequest`
- [x] Add logout API call in service
- [x] Add logout service call in repository and add corresponding unit tests
- [x] Create `LogoutUseCase` and corresponding unit tests

## Insight 📝

- Once logging out, we will clear all of the caches (both surveys and tokens cache)

## Proof Of Work 📹

```
flutter: *** Request ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/oauth/revoke
flutter: method: POST
flutter: responseType: ResponseType.json
flutter: followRedirects: true
flutter: connectTimeout: 30000
flutter: sendTimeout: 0
flutter: receiveTimeout: 30000
flutter: receiveDataWhenStatusError: true
flutter: extra: {}
flutter: headers:
flutter:  content-type: application/json; charset=utf-8
flutter: data:
flutter: {token: HxfsCEPFRtBxIsuGLHG4R11AXUapQ73a5hibBwljPac, client_id: 4gg3bokkvPnMxWz7HHTdM_wf1RNg9k8iA6sZ2ZrA7EA, client_secret: y_GgV-GEjWd3VTzbZBS6tqEco0E68QuqHQv0QND2vKo}
flutter:
flutter: *** Response ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/oauth/revoke
flutter: statusCode: 200
flutter: headers:
flutter:  connection: keep-alive
flutter:  cache-control: max-age=0, private, must-revalidate
flutter:  transfer-encoding: chunked
flutter:  date: Mon, 26 Dec 2022 07:43:53 GMT
flutter:  vary: Accept-Encoding, Origin
flutter:  content-encoding: gzip
flutter:  strict-transport-security: max-age=31536000; includeSubDomains
flutter:  referrer-policy: strict-origin-when-cross-origin
flutter:  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=xUOFiSySBA6dm%2BAtixlwGZWXezDVwC0KUTbd2Q1OwlgG876dcdExKrN35wFEtaLX0owpBP6urhsB5nos9NC38gKHNuJOnXCnhTObwQ46ksLBqx6wycDgJAsCTEksKH3WAu2pKTuq%2FRKc"}],"group":"cf-nel","max_age":604800}
flutter:  cf-cache-status: DYNAMIC
flutter:  x-permitted-cross-domain-policies: none
flutter:  content-type: application/json; charset=utf-8
flutter:  x-xss-protection: 1; mode=block
flutter:  server: cloudflare
flutter:  x-request-id: 3092d64c-dc19-4ac6-92c9-826300e3037b
flutter:  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
flutter:  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
flutter:  x-download-options: noopen
flutter:  cf-ray: 77f830275cca5aca-BKK
flutter:  x-runtime: 0.013030
flutter:  etag: W/"5768fdcc51913951060b5cf9e59e6b77"
flutter:  via: 1.1 vegur
flutter:  x-frame-options: SAMEORIGIN
flutter:  x-content-type-options: nosniff
flutter: Response Text:
flutter: {}
flutter:
```
