### PR TITLE
[#14] Integrate Home drawer

### DIFF
--- a/assets/color/colors.xml
+++ b/assets/color/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="chinese_black">#15151A</color>
-    <color name="raisin_black">#252525</color>
     <color name="eerie_black_90">#E61E1E1E</color>
+    <color name="raisin_black">#252525</color>
 </resources>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:survey/di/di.dart';
 import 'package:survey/model/survey_model.dart';
 import 'package:survey/navigator.dart';
-import 'package:survey/page/login/login_page.dart';
 import 'package:survey/resource/app_theme.dart';
 
 void main() async {
@@ -28,7 +27,6 @@ class App extends StatelessWidget {
       theme: AppTheme.defaultTheme,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: LoginPage(),
       routes: Routes.routes,
     );
   }

--- a/lib/navigator.dart
+++ b/lib/navigator.dart
@@ -4,9 +4,9 @@ import 'package:survey/page/home/home_page.dart';
 import 'package:survey/page/login/login_page.dart';
 import 'package:survey/page/resetpassword/reset_password_page.dart';
 
-const String _routeLogin = 'login';
-const String _routeHome = 'home';
-const String _routeResetPassword = 'resetPassword';
+const String _routeLogin = '/';
+const String _routeHome = '/home';
+const String _routeResetPassword = '/reset-password';
 
 class Routes {
   static final routes = <String, WidgetBuilder>{
@@ -22,6 +22,8 @@ abstract class AppNavigator {
   void navigateToHome(BuildContext context);
 
   void navigateToResetPassword(BuildContext context);
+
+  void navigateToLoginAndClearStack(BuildContext context);
 }
 
 @Injectable(as: AppNavigator)
@@ -36,4 +38,8 @@ class AppNavigatorImpl extends AppNavigator {
   @override
   void navigateToResetPassword(BuildContext context) =>
       Navigator.of(context).pushNamed(_routeResetPassword);
+
+  @override
+  void navigateToLoginAndClearStack(BuildContext context) =>
+      Navigator.pushNamedAndRemoveUntil(context, _routeLogin, (r) => false);
 }

--- a/lib/page/home/home_state.dart
+++ b/lib/page/home/home_state.dart
@@ -13,4 +13,6 @@ class HomeState with _$HomeState {
   const factory HomeState.apiLoadingSuccess() = _ApiLoadingSuccess;
 
   const factory HomeState.loadSurveysError() = _LoadSurveysError;
+
+  const factory HomeState.logoutSuccess() = _LogoutSuccess;
 }

--- a/lib/page/home/widget/home_drawer_widget.dart
+++ b/lib/page/home/widget/home_drawer_widget.dart
@@ -1,11 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:survey/gen/colors.gen.dart';
+import 'package:survey/model/user_model.dart';
 import 'package:survey/page/home/widget/home_user_avatar_widget.dart';
 import 'package:survey/resource/dimens.dart';
 
 class HomeDrawerWidget extends StatelessWidget {
-  const HomeDrawerWidget({super.key});
+  final UserModel? user;
+  final VoidCallback logout;
+  final String appVersion;
+
+  const HomeDrawerWidget({
+    Key? key,
+    required this.user,
+    required this.logout,
+    required this.appVersion,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -30,16 +40,14 @@ class HomeDrawerWidget extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.only(right: Dimens.space8),
                       child: Text(
-                        // TODO: Display user name from API
-                        AppLocalizations.of(context)!.homeUser,
+                        user?.name ?? AppLocalizations.of(context)!.homeUser,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.headline5,
                       ),
                     ),
                   ),
-                  // TODO: Display user avatar from API
-                  HomeUserAvatarWidget(userAvatarUrl: null),
+                  HomeUserAvatarWidget(userAvatarUrl: user?.avatarUrl),
                 ]),
                 const SizedBox(height: Dimens.space20),
                 Container(
@@ -49,7 +57,7 @@ class HomeDrawerWidget extends StatelessWidget {
                 ),
                 const SizedBox(height: Dimens.space35),
                 TextButton(
-                  onPressed: () {},
+                  onPressed: () => logout.call(),
                   child: Text(
                     AppLocalizations.of(context)!.homeLogout,
                     style: Theme.of(context).textTheme.bodyText1?.copyWith(
@@ -60,8 +68,7 @@ class HomeDrawerWidget extends StatelessWidget {
                 ),
                 const Expanded(child: const SizedBox.shrink()),
                 Text(
-                  // TODO: Display version number
-                  'v0.1.0 (1562903885)',
+                  appVersion,
                   style: Theme.of(context).textTheme.caption?.copyWith(
                         color: Colors.white.withOpacity(0.5),
                       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -525,6 +525,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   page_view_dot_indicator:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   japx: ^2.0.4
   json_annotation: ^4.6.0
   loading_indicator: ^3.1.0
+  package_info_plus: ^3.0.2
   page_view_dot_indicator: ^2.0.1
   retrofit: ^3.0.1+1
   rxdart: ^0.27.7

--- a/test/mock/mock_dependencies.dart
+++ b/test/mock/mock_dependencies.dart
@@ -14,6 +14,7 @@ import 'package:survey/usecase/get_cached_surveys_use_case.dart';
 import 'package:survey/usecase/get_surveys_use_case.dart';
 import 'package:survey/usecase/get_user_use_case.dart';
 import 'package:survey/usecase/login_use_case.dart';
+import 'package:survey/usecase/logout_use_case.dart';
 import 'package:survey/usecase/reset_password_use_case.dart';
 
 @GenerateNiceMocks([
@@ -30,6 +31,7 @@ import 'package:survey/usecase/reset_password_use_case.dart';
   MockSpec<GetCachedSurveysUseCase>(),
   MockSpec<GetUserUseCase>(),
   MockSpec<ResetPasswordUseCase>(),
+  MockSpec<LogoutUseCase>(),
   MockSpec<UserModel>(),
   MockSpec<DioError>(),
   MockSpec<UseCaseException>(),

--- a/test/page/home/home_view_model_test.dart
+++ b/test/page/home/home_view_model_test.dart
@@ -16,6 +16,7 @@ void main() {
     late MockGetUserUseCase mockGetUserUseCase;
     late MockGetSurveysUseCase mockGetSurveysUseCase;
     late MockGetCachedSurveysUseCase mockGetCachedSurveysUseCase;
+    late MockLogoutUseCase mockLogoutUseCase;
     late MockUseCaseException mockException;
     late ProviderContainer providerContainer;
     late HomeViewModel homeViewModel;
@@ -41,6 +42,7 @@ void main() {
       mockGetUserUseCase = MockGetUserUseCase();
       mockGetSurveysUseCase = MockGetSurveysUseCase();
       mockGetCachedSurveysUseCase = MockGetCachedSurveysUseCase();
+      mockLogoutUseCase = MockLogoutUseCase();
       mockException = MockUseCaseException();
 
       when(mockGetCachedSurveysUseCase.call()).thenAnswer((_) => cachedSurveys);
@@ -53,6 +55,7 @@ void main() {
             mockGetUserUseCase,
             mockGetSurveysUseCase,
             mockGetCachedSurveysUseCase,
+            mockLogoutUseCase,
           )),
         ],
       );
@@ -163,6 +166,37 @@ void main() {
       expect(stateStream, emitsInOrder([const HomeState.loadSurveysError()]));
 
       homeViewModel.refreshSurveys();
+    });
+
+    test('When logging out with Success result, it returns LogoutSuccess state',
+        () async {
+      when(mockLogoutUseCase.call()).thenAnswer((_) async => Success(null));
+      final stateStream = homeViewModel.stream;
+
+      expect(
+          stateStream,
+          emitsInOrder([
+            const HomeState.loading(),
+            const HomeState.logoutSuccess(),
+          ]));
+
+      homeViewModel.logout();
+    });
+
+    test(
+        'When logging out with Failed result, it emits corresponding errorMessage',
+        () async {
+      when(mockLogoutUseCase.call())
+          .thenAnswer((_) async => Failed(mockException));
+      final errorStream = homeViewModel.error;
+
+      expect(
+          errorStream,
+          emitsInOrder([
+            NetworkExceptions.getErrorMessage(NetworkExceptions.badRequest())
+          ]));
+
+      homeViewModel.logout();
     });
 
     test(


### PR DESCRIPTION
#14

## What happened 👀

- [x] Display the user name and user profile image at the top of the drawer
- [x] When tapping on "Logout", we will call Logout API through the view model
  - We will close the drawer and show Loading Indicator
  - If the API call return Success, we will show the Login screen
  - If the API call return Failed, we will show the SnackBar with the error message
- [x] Display the app version at the bottom of the drawer
- [x] Add unit tests for `HomeViewModel`
- [x] Refactor `Navigator`

## Insight 📝

- We use [package_info_plus](https://pub.dev/packages/package_info_plus) for retrieving the app version

## Proof Of Work 📹

https://user-images.githubusercontent.com/13492460/209561732-903ea5dd-2f13-41a2-b699-264aeca79041.mov
