### PR TITLE
[#84] Handle start screen

### DIFF
--- a/lib/database/shared_preferences_utils.dart
+++ b/lib/database/shared_preferences_utils.dart
@@ -14,6 +14,8 @@ abstract class SharedPreferencesUtils {
 
   String get authToken;
 
+  bool get isLoggedIn;
+
   void saveAccessToken(String accessToken);
 
   void saveTokenType(String tokenType);
@@ -41,6 +43,11 @@ class SharedPreferencesUtilsImpl extends SharedPreferencesUtils {
 
   @override
   String get authToken => '$tokenType $accessToken';
+
+  @override
+  bool get isLoggedIn =>
+      _sharedPreferences.containsKey(_accessTokenKey) &&
+      _sharedPreferences.containsKey(_tokenTypeKey);
 
   @override
   void saveAccessToken(String accessToken) async {

--- a/lib/navigator.dart
+++ b/lib/navigator.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:injectable/injectable.dart';
 import 'package:survey/page/home/home_page.dart';
-import 'package:survey/page/login/login_page.dart';
 import 'package:survey/page/resetpassword/reset_password_page.dart';
+import 'package:survey/page/start/start_page.dart';
 
-const String _routeLogin = '/';
+const String _routeStart = '/';
 const String _routeHome = '/home';
 const String _routeResetPassword = '/reset-password';
 
 class Routes {
   static final routes = <String, WidgetBuilder>{
-    _routeLogin: (BuildContext context) => const LoginPage(),
+    _routeStart: (BuildContext context) => StartPage(),
     _routeHome: (BuildContext context) => const HomePage(),
     _routeResetPassword: (BuildContext context) => const ResetPasswordPage(),
   };
@@ -19,11 +19,11 @@ class Routes {
 abstract class AppNavigator {
   void navigateBack(BuildContext context);
 
-  void navigateToHome(BuildContext context);
+  void navigateToHomeAndClearStack(BuildContext context);
 
   void navigateToResetPassword(BuildContext context);
 
-  void navigateToLoginAndClearStack(BuildContext context);
+  void navigateToStartAndClearStack(BuildContext context);
 }
 
 @Injectable(as: AppNavigator)
@@ -32,14 +32,14 @@ class AppNavigatorImpl extends AppNavigator {
   void navigateBack(BuildContext context) => Navigator.of(context).pop();
 
   @override
-  void navigateToHome(BuildContext context) =>
-      Navigator.of(context).pushNamed(_routeHome);
+  void navigateToHomeAndClearStack(BuildContext context) =>
+      Navigator.pushNamedAndRemoveUntil(context, _routeHome, (r) => false);
 
   @override
   void navigateToResetPassword(BuildContext context) =>
       Navigator.of(context).pushNamed(_routeResetPassword);
 
   @override
-  void navigateToLoginAndClearStack(BuildContext context) =>
-      Navigator.pushNamedAndRemoveUntil(context, _routeLogin, (r) => false);
+  void navigateToStartAndClearStack(BuildContext context) =>
+      Navigator.pushNamedAndRemoveUntil(context, _routeStart, (r) => false);
 }

--- a/lib/page/home/home_page.dart
+++ b/lib/page/home/home_page.dart
@@ -71,7 +71,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     ) {
       newState.maybeWhen(
         logoutSuccess: () =>
-            _appNavigator.navigateToLoginAndClearStack(context),
+            _appNavigator.navigateToStartAndClearStack(context),
         orElse: () {},
       );
     });

--- a/lib/page/login/login_page.dart
+++ b/lib/page/login/login_page.dart
@@ -104,7 +104,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     );
   }
 
-  void _navigateToHome() => _appNavigator.navigateToHome(context);
+  void _navigateToHome() => _appNavigator.navigateToHomeAndClearStack(context);
 
   void _navigateToResetPassword() =>
       _appNavigator.navigateToResetPassword(context);

--- a/lib/page/start/start_page.dart
+++ b/lib/page/start/start_page.dart
@@ -11,10 +11,6 @@ class StartPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (_sharedPreferencesUtils.isLoggedIn) {
-      return HomePage();
-    } else {
-      return LoginPage();
-    }
+    return _sharedPreferencesUtils.isLoggedIn ? HomePage() : LoginPage();
   }
 }

--- a/lib/page/start/start_page.dart
+++ b/lib/page/start/start_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:survey/database/shared_preferences_utils.dart';
+import 'package:survey/di/di.dart';
+import 'package:survey/page/home/home_page.dart';
+import 'package:survey/page/login/login_page.dart';
+
+class StartPage extends StatelessWidget {
+  StartPage({super.key});
+
+  final _sharedPreferencesUtils = getIt.get<SharedPreferencesUtils>();
+
+  @override
+  Widget build(BuildContext context) {
+    if (_sharedPreferencesUtils.isLoggedIn) {
+      return HomePage();
+    } else {
+      return LoginPage();
+    }
+  }
+}


### PR DESCRIPTION
#84 

## What happened 👀

- [x] Create the Start screen and set it as a home destination
- [x] On the Start screen, we will check the `isLoggedIn` flag (retrieving from `SharedPrefernces` by checking tokens availability) to see if the user has already logged in or not
  - If the user has already logged in, we will bring the user to the Home page
  - If the user has not logged in yet, we will bring the user to the Login page

## Insight 📝

N/A

## Proof Of Work 📹

https://user-images.githubusercontent.com/13492460/209562440-b80a97f6-c80e-4f70-8398-646c63189a27.mov
