### PR TITLE
[#23] Integrate Survey Detail screen

### DIFF
--- a/lib/api/response/question_response.dart
+++ b/lib/api/response/question_response.dart
@@ -44,4 +44,12 @@ class QuestionResponse {
 
   factory QuestionResponse.fromJson(Map<String, dynamic> json) =>
       _$QuestionResponseFromJson(fromDataJsonApi(json));
+
+  String getHdCoverImageUrl() {
+    if (coverImageUrl != null) {
+      return "${coverImageUrl}l";
+    } else {
+      return "";
+    }
+  }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -3,4 +3,5 @@ class Constants {
 
   static const int snackBarDurationInSecond = 2;
   static const int firstSurveysPageNumber = 1;
+  static const double defaultDimmedBackgroundOpacity = 0.4;
 }

--- a/lib/model/question_model.dart
+++ b/lib/model/question_model.dart
@@ -43,7 +43,7 @@ class QuestionModel extends Equatable {
       displayType: response.displayType ?? DisplayType.unknown,
       imageUrl: response.imageUrl ?? '',
       coverImageOpacity: response.coverImageOpacity ?? 0,
-      coverImageUrl: response.coverImageUrl ?? '',
+      coverImageUrl: response.getHdCoverImageUrl(),
       answers: response.answers
           .map((answer) => AnswerModel.fromResponse(answer))
           .toList(),

--- a/lib/navigator.dart
+++ b/lib/navigator.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:injectable/injectable.dart';
+import 'package:survey/model/survey_detail_model.dart';
+import 'package:survey/model/survey_model.dart';
 import 'package:survey/page/home/home_page.dart';
+import 'package:survey/page/question/question_page.dart';
 import 'package:survey/page/resetpassword/reset_password_page.dart';
 import 'package:survey/page/start/start_page.dart';
 import 'package:survey/page/surveydetail/survey_detail_page.dart';
@@ -9,6 +12,7 @@ const String _routeStart = '/';
 const String _routeHome = '/home';
 const String _routeResetPassword = '/reset-password';
 const String _routeSurveyDetail = '/survey-detail';
+const String _routeQuestion = '/question';
 
 class Routes {
   static final routes = <String, WidgetBuilder>{
@@ -16,6 +20,7 @@ class Routes {
     _routeHome: (BuildContext context) => const HomePage(),
     _routeResetPassword: (BuildContext context) => const ResetPasswordPage(),
     _routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
+    _routeQuestion: (BuildContext context) => const QuestionPage(),
   };
 }
 
@@ -28,7 +33,9 @@ abstract class AppNavigator {
 
   void navigateToStartAndClearStack(BuildContext context);
 
-  void navigateToSurveyDetail(BuildContext context, String surveyId);
+  void navigateToSurveyDetail(BuildContext context, SurveyModel survey);
+
+  void navigateToQuestion(BuildContext context, SurveyDetailModel surveyDetail);
 }
 
 @Injectable(as: AppNavigator)
@@ -49,9 +56,14 @@ class AppNavigatorImpl extends AppNavigator {
       Navigator.pushNamedAndRemoveUntil(context, _routeStart, (r) => false);
 
   @override
-  void navigateToSurveyDetail(BuildContext context, String surveyId) =>
+  void navigateToSurveyDetail(BuildContext context, SurveyModel survey) =>
       Navigator.of(context).pushNamed(
         _routeSurveyDetail,
-        arguments: surveyId,
+        arguments: survey,
       );
+
+  @override
+  void navigateToQuestion(
+          BuildContext context, SurveyDetailModel surveyDetail) =>
+      Navigator.of(context).pushNamed(_routeQuestion);
 }

--- a/lib/page/home/widget/home_surveys_page_view_widget.dart
+++ b/lib/page/home/widget/home_surveys_page_view_widget.dart
@@ -42,7 +42,7 @@ class HomeSurveysPageViewWidget extends ConsumerWidget {
         return HomeSurveysItemWidget(
           survey: surveys[index],
           onNextButtonPressed: () =>
-              _appNavigator.navigateToSurveyDetail(context, surveys[index].id),
+              _appNavigator.navigateToSurveyDetail(context, surveys[index]),
         );
       },
       onPageChanged: (int index) {

--- a/lib/page/login/login_state.dart
+++ b/lib/page/login/login_state.dart
@@ -10,7 +10,7 @@ class LoginState with _$LoginState {
 
   const factory LoginState.success() = _Success;
 
-  const factory LoginState.apiError(String errorMessage) = _Error;
+  const factory LoginState.apiError(String errorMessage) = _ApiError;
 
   const factory LoginState.invalidInputsError() = _InvalidInputsError;
 }

--- a/lib/page/question/question_page.dart
+++ b/lib/page/question/question_page.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class QuestionPage extends StatelessWidget {
+  const QuestionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/lib/page/resetpassword/reset_password_state.dart
+++ b/lib/page/resetpassword/reset_password_state.dart
@@ -10,7 +10,7 @@ class ResetPasswordState with _$ResetPasswordState {
 
   const factory ResetPasswordState.success() = _Success;
 
-  const factory ResetPasswordState.apiError(String errorMessage) = _Error;
+  const factory ResetPasswordState.apiError(String errorMessage) = _ApiError;
 
   const factory ResetPasswordState.invalidInputError() = _InvalidInputError;
 }

--- a/lib/page/surveydetail/survey_detail_page.dart
+++ b/lib/page/surveydetail/survey_detail_page.dart
@@ -1,27 +1,104 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey/api/response/question_response.dart';
+import 'package:survey/constants.dart';
+import 'package:survey/di/di.dart';
+import 'package:survey/model/survey_detail_model.dart';
+import 'package:survey/model/survey_model.dart';
+import 'package:survey/navigator.dart';
+import 'package:survey/page/surveydetail/survey_detail_state.dart';
+import 'package:survey/page/surveydetail/survey_detail_view_model.dart';
 import 'package:survey/resource/dimens.dart';
+import 'package:survey/usecase/get_survey_detail_use_case.dart';
 import 'package:survey/widget/app_bar_back_button_widget.dart';
 import 'package:survey/widget/dimmed_background_widget.dart';
+import 'package:survey/widget/loading_indicator_widget.dart';
 import 'package:survey/widget/rounded_button_widget.dart';
 
-class SurveyDetailPage extends StatelessWidget {
+final surveyDetailViewModelProvider =
+    StateNotifierProvider.autoDispose<SurveyDetailViewModel, SurveyDetailState>(
+        (ref) {
+  return SurveyDetailViewModel(getIt.get<GetSurveyDetailUseCase>());
+});
+
+final _surveyStreamProvider = StreamProvider.autoDispose<SurveyModel>(
+    (ref) => ref.watch(surveyDetailViewModelProvider.notifier).survey);
+
+final _surveyDetailStreamProvider =
+    StreamProvider.autoDispose<SurveyDetailModel>((ref) =>
+        ref.watch(surveyDetailViewModelProvider.notifier).surveyDetail);
+
+class SurveyDetailPage extends ConsumerStatefulWidget {
   const SurveyDetailPage({super.key});
 
   @override
+  _SurveyDetailPageState createState() => _SurveyDetailPageState();
+}
+
+class _SurveyDetailPageState extends ConsumerState<SurveyDetailPage> {
+  final _appNavigator = getIt.get<AppNavigator>();
+
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(Duration.zero, () {
+      final survey = ModalRoute.of(context)!.settings.arguments as SurveyModel;
+      ref.read(surveyDetailViewModelProvider.notifier).getSurveyDetail(survey);
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    // TODO: Retrieve surveyId
-    // final surveyId = ModalRoute.of(context)!.settings.arguments as String;
+    final survey = ref.watch(_surveyStreamProvider).value;
+    final surveyDetail = ref.watch(_surveyDetailStreamProvider).value;
+
+    ref.listen<SurveyDetailState>(surveyDetailViewModelProvider, (
+      SurveyDetailState? previousState,
+      SurveyDetailState newState,
+    ) {
+      newState.maybeWhen(
+        retrySuccess: () {
+          if (surveyDetail != null) _navigateToQuestion(surveyDetail);
+        },
+        orElse: () {},
+      );
+    });
+
+    return ref.watch(surveyDetailViewModelProvider).when(
+          init: () => _buildSurveyDetailPage(survey),
+          loading: () =>
+              _buildSurveyDetailPage(survey, shouldShowLoading: true),
+          success: () =>
+              _buildSurveyDetailPage(survey, surveyDetail: surveyDetail),
+          error: (errorMessage) {
+            _showError(errorMessage);
+            return _buildSurveyDetailPage(survey);
+          },
+          retrySuccess: () => const SizedBox(),
+        );
+  }
+
+  Widget _buildSurveyDetailPage(
+    SurveyModel? survey, {
+    SurveyDetailModel? surveyDetail = null,
+    bool shouldShowLoading = false,
+  }) {
+    final introQuestion = surveyDetail?.questions.firstWhereOrNull(
+      (question) => question.displayType == DisplayType.intro,
+    );
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: Stack(
         children: [
           DimmedBackgroundWidget(
-            // TODO: Display survey's background image
             background: Image.network(
-                    'https://upload.wikimedia.org/wikipedia/en/2/27/Bliss_%28Windows_XP%29.png')
-                .image,
+              introQuestion?.coverImageUrl ?? survey?.coverImageUrl ?? '',
+            ).image,
+            opacity: introQuestion?.coverImageOpacity ??
+                Constants.defaultDimmedBackgroundOpacity,
           ),
           SafeArea(
             child: Padding(
@@ -42,14 +119,12 @@ class SurveyDetailPage extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            // TODO: Display survey's title
-                            'Title',
+                            survey?.title ?? '',
                             style: Theme.of(context).textTheme.headline5,
                           ),
                           const SizedBox(height: Dimens.space16),
                           Text(
-                            // TODO: Display survey's description
-                            'Description',
+                            introQuestion?.text ?? survey?.description ?? '',
                             style: Theme.of(context)
                                 .textTheme
                                 .bodyText1
@@ -66,7 +141,14 @@ class SurveyDetailPage extends StatelessWidget {
                       buttonText:
                           AppLocalizations.of(context)!.surveyDetailStartSurvey,
                       onPressed: () {
-                        // TODO: Navigate to Questions screen
+                        if (surveyDetail != null) {
+                          _navigateToQuestion(surveyDetail);
+                        } else {
+                          if (survey != null)
+                            ref
+                                .read(surveyDetailViewModelProvider.notifier)
+                                .getSurveyDetail(survey, isRetry: true);
+                        }
                       },
                     ),
                   ),
@@ -74,8 +156,22 @@ class SurveyDetailPage extends StatelessWidget {
               ),
             ),
           ),
+          if (shouldShowLoading)
+            LoadingIndicatorWidget(shouldIgnoreOtherGestures: true),
         ],
       ),
     );
+  }
+
+  void _navigateToQuestion(SurveyDetailModel surveyDetail) =>
+      _appNavigator.navigateToQuestion(context, surveyDetail);
+
+  void _showError(String errorMessage) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        duration: const Duration(seconds: Constants.snackBarDurationInSecond),
+        content: Text(errorMessage),
+      ));
+    });
   }
 }

--- a/lib/page/surveydetail/survey_detail_page.dart
+++ b/lib/page/surveydetail/survey_detail_page.dart
@@ -59,9 +59,7 @@ class _SurveyDetailPageState extends ConsumerState<SurveyDetailPage> {
       SurveyDetailState newState,
     ) {
       newState.maybeWhen(
-        retrySuccess: () {
-          if (surveyDetail != null) _navigateToQuestion(surveyDetail);
-        },
+        retrySuccess: (surveyDetail) => _navigateToQuestion(surveyDetail),
         orElse: () {},
       );
     });
@@ -76,7 +74,7 @@ class _SurveyDetailPageState extends ConsumerState<SurveyDetailPage> {
             _showError(errorMessage);
             return _buildSurveyDetailPage(survey);
           },
-          retrySuccess: () => const SizedBox(),
+          retrySuccess: (_) => const SizedBox(),
         );
   }
 

--- a/lib/page/surveydetail/survey_detail_state.dart
+++ b/lib/page/surveydetail/survey_detail_state.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'survey_detail_state.freezed.dart';
+
+@freezed
+class SurveyDetailState with _$SurveyDetailState {
+  const factory SurveyDetailState.init() = _Init;
+
+  const factory SurveyDetailState.loading() = _Loading;
+
+  const factory SurveyDetailState.success() = _Success;
+
+  const factory SurveyDetailState.retrySuccess() = _RetrySuccess;
+
+  const factory SurveyDetailState.error(String errorMessage) = _Error;
+}

--- a/lib/page/surveydetail/survey_detail_state.dart
+++ b/lib/page/surveydetail/survey_detail_state.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:survey/model/survey_detail_model.dart';
 
 part 'survey_detail_state.freezed.dart';
 
@@ -10,7 +11,8 @@ class SurveyDetailState with _$SurveyDetailState {
 
   const factory SurveyDetailState.success() = _Success;
 
-  const factory SurveyDetailState.retrySuccess() = _RetrySuccess;
+  const factory SurveyDetailState.retrySuccess(SurveyDetailModel surveyDetail) =
+      _RetrySuccess;
 
   const factory SurveyDetailState.error(String errorMessage) = _Error;
 }

--- a/lib/page/surveydetail/survey_detail_view_model.dart
+++ b/lib/page/surveydetail/survey_detail_view_model.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rxdart/subjects.dart';
+import 'package:survey/model/survey_detail_model.dart';
+import 'package:survey/model/survey_model.dart';
+import 'package:survey/page/surveydetail/survey_detail_state.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+import 'package:survey/usecase/get_survey_detail_use_case.dart';
+
+class SurveyDetailViewModel extends StateNotifier<SurveyDetailState> {
+  final GetSurveyDetailUseCase _getSurveyDetailUseCase;
+
+  SurveyDetailViewModel(this._getSurveyDetailUseCase)
+      : super(const SurveyDetailState.init());
+
+  final BehaviorSubject<SurveyModel> _survey = BehaviorSubject();
+
+  Stream<SurveyModel> get survey => _survey.stream;
+
+  final BehaviorSubject<SurveyDetailModel> _surveyDetail = BehaviorSubject();
+
+  Stream<SurveyDetailModel> get surveyDetail => _surveyDetail.stream;
+
+  void getSurveyDetail(SurveyModel survey, {isRetry = false}) async {
+    if (!isRetry) _survey.add(survey);
+    state = const SurveyDetailState.loading();
+    Result<SurveyDetailModel> result =
+        await _getSurveyDetailUseCase.call(survey.id);
+    if (result is Success<SurveyDetailModel>) {
+      _surveyDetail.add(result.value);
+      if (!isRetry) {
+        state = SurveyDetailState.success();
+      } else {
+        state = SurveyDetailState.retrySuccess();
+      }
+    } else {
+      state = SurveyDetailState.error((result as Failed).getErrorMessage());
+    }
+  }
+}

--- a/lib/page/surveydetail/survey_detail_view_model.dart
+++ b/lib/page/surveydetail/survey_detail_view_model.dart
@@ -26,11 +26,12 @@ class SurveyDetailViewModel extends StateNotifier<SurveyDetailState> {
     Result<SurveyDetailModel> result =
         await _getSurveyDetailUseCase.call(survey.id);
     if (result is Success<SurveyDetailModel>) {
-      _surveyDetail.add(result.value);
+      final surveyDetail = result.value;
       if (!isRetry) {
+        _surveyDetail.add(surveyDetail);
         state = SurveyDetailState.success();
       } else {
-        state = SurveyDetailState.retrySuccess();
+        state = SurveyDetailState.retrySuccess(surveyDetail);
       }
     } else {
       state = SurveyDetailState.error((result as Failed).getErrorMessage());

--- a/lib/widget/dimmed_background_widget.dart
+++ b/lib/widget/dimmed_background_widget.dart
@@ -1,14 +1,17 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:survey/constants.dart';
 
 class DimmedBackgroundWidget extends StatelessWidget {
   final ImageProvider background;
+  final double opacity;
   final bool shouldBlur;
 
   const DimmedBackgroundWidget({
     Key? key,
     required this.background,
+    this.opacity = Constants.defaultDimmedBackgroundOpacity,
     this.shouldBlur = false,
   }) : super(key: key);
 
@@ -21,7 +24,7 @@ class DimmedBackgroundWidget extends StatelessWidget {
         image: DecorationImage(
           image: background,
           colorFilter: ColorFilter.mode(
-            Colors.black.withOpacity(0.4),
+            Colors.black.withOpacity(opacity),
             BlendMode.darken,
           ),
           fit: BoxFit.cover,

--- a/test/mock/mock_dependencies.dart
+++ b/test/mock/mock_dependencies.dart
@@ -9,9 +9,11 @@ import 'package:survey/api/service/user_service.dart';
 import 'package:survey/database/hive_utils.dart';
 import 'package:survey/database/shared_preferences_utils.dart';
 import 'package:survey/model/survey_detail_model.dart';
+import 'package:survey/model/survey_model.dart';
 import 'package:survey/model/user_model.dart';
 import 'package:survey/usecase/base/base_use_case.dart';
 import 'package:survey/usecase/get_cached_surveys_use_case.dart';
+import 'package:survey/usecase/get_survey_detail_use_case.dart';
 import 'package:survey/usecase/get_surveys_use_case.dart';
 import 'package:survey/usecase/get_user_use_case.dart';
 import 'package:survey/usecase/login_use_case.dart';
@@ -33,7 +35,9 @@ import 'package:survey/usecase/reset_password_use_case.dart';
   MockSpec<GetUserUseCase>(),
   MockSpec<ResetPasswordUseCase>(),
   MockSpec<LogoutUseCase>(),
+  MockSpec<GetSurveyDetailUseCase>(),
   MockSpec<UserModel>(),
+  MockSpec<SurveyModel>(),
   MockSpec<SurveyDetailModel>(),
   MockSpec<DioError>(),
   MockSpec<UseCaseException>(),

--- a/test/page/surveydetail/survey_detail_view_model_test.dart
+++ b/test/page/surveydetail/survey_detail_view_model_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/page/surveydetail/survey_detail_page.dart';
+import 'package:survey/page/surveydetail/survey_detail_state.dart';
+import 'package:survey/page/surveydetail/survey_detail_view_model.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+
+import '../../mock/mock_dependencies.mocks.dart';
+
+void main() {
+  group('SurveyDetailViewModelTest', () {
+    late MockGetSurveyDetailUseCase mockGetSurveyDetailUseCase;
+    late ProviderContainer providerContainer;
+    late SurveyDetailViewModel surveyDetailViewModel;
+
+    final survey = MockSurveyModel();
+
+    setUp(() {
+      mockGetSurveyDetailUseCase = MockGetSurveyDetailUseCase();
+
+      providerContainer = ProviderContainer(
+        overrides: [
+          surveyDetailViewModelProvider.overrideWithValue(
+              SurveyDetailViewModel(mockGetSurveyDetailUseCase)),
+        ],
+      );
+      addTearDown(providerContainer.dispose);
+      surveyDetailViewModel =
+          providerContainer.read(surveyDetailViewModelProvider.notifier);
+    });
+
+    test('When initializing, it initializes with Init state', () {
+      expect(
+        providerContainer.read(surveyDetailViewModelProvider),
+        const SurveyDetailState.init(),
+      );
+    });
+
+    test(
+        'When calling get survey detail with Success result and isRetry is false, it emits SurveyModel, SurveyDetailModel and returns Success state',
+        () {
+      final surveyDetail = MockSurveyDetailModel();
+      when(mockGetSurveyDetailUseCase.call(any))
+          .thenAnswer((_) async => Success(surveyDetail));
+      final stateStream = surveyDetailViewModel.stream;
+      final surveyStream = surveyDetailViewModel.survey;
+      final surveyDetailStream = surveyDetailViewModel.surveyDetail;
+
+      expect(
+          stateStream,
+          emitsInOrder([
+            const SurveyDetailState.loading(),
+            const SurveyDetailState.success(),
+          ]));
+      expect(surveyStream, emitsInOrder([survey]));
+      expect(surveyDetailStream, emitsInOrder([surveyDetail]));
+
+      surveyDetailViewModel.getSurveyDetail(survey);
+    });
+
+    test(
+        'When calling get survey detail with Success result and isRetry is true, it emits SurveyDetailModel and returns RetrySuccess state',
+        () {
+      final surveyDetail = MockSurveyDetailModel();
+      when(mockGetSurveyDetailUseCase.call(any))
+          .thenAnswer((_) async => Success(surveyDetail));
+      final stateStream = surveyDetailViewModel.stream;
+      final surveyDetailStream = surveyDetailViewModel.surveyDetail;
+
+      expect(
+          stateStream,
+          emitsInOrder([
+            const SurveyDetailState.loading(),
+            const SurveyDetailState.retrySuccess(),
+          ]));
+      expect(surveyDetailStream, emitsInOrder([surveyDetail]));
+
+      surveyDetailViewModel.getSurveyDetail(survey, isRetry: true);
+    });
+
+    test(
+        'When calling get survey detail with Failed result, it returns Error state with corresponding errorMessage',
+        () {
+      final mockException = MockUseCaseException();
+      when(mockException.actualException)
+          .thenReturn(NetworkExceptions.badRequest());
+      when(mockGetSurveyDetailUseCase.call(any))
+          .thenAnswer((_) async => Failed(mockException));
+      final stateStream = surveyDetailViewModel.stream;
+
+      expect(
+          stateStream,
+          emitsInOrder([
+            const SurveyDetailState.loading(),
+            SurveyDetailState.error(
+              NetworkExceptions.getErrorMessage(NetworkExceptions.badRequest()),
+            ),
+          ]));
+
+      surveyDetailViewModel.getSurveyDetail(survey);
+    });
+  });
+}

--- a/test/page/surveydetail/survey_detail_view_model_test.dart
+++ b/test/page/surveydetail/survey_detail_view_model_test.dart
@@ -61,21 +61,19 @@ void main() {
     });
 
     test(
-        'When calling get survey detail with Success result and isRetry is true, it emits SurveyDetailModel and returns RetrySuccess state',
+        'When calling get survey detail with Success result and isRetry is true, it returns RetrySuccess state with SurveyDetailModel',
         () {
       final surveyDetail = MockSurveyDetailModel();
       when(mockGetSurveyDetailUseCase.call(any))
           .thenAnswer((_) async => Success(surveyDetail));
       final stateStream = surveyDetailViewModel.stream;
-      final surveyDetailStream = surveyDetailViewModel.surveyDetail;
 
       expect(
           stateStream,
           emitsInOrder([
             const SurveyDetailState.loading(),
-            const SurveyDetailState.retrySuccess(),
+            SurveyDetailState.retrySuccess(surveyDetail),
           ]));
-      expect(surveyDetailStream, emitsInOrder([surveyDetail]));
 
       surveyDetailViewModel.getSurveyDetail(survey, isRetry: true);
     });


### PR DESCRIPTION
#23

## What happened 👀

- [x] When tapping on the Next button on each survey item, we will navigate to the Survey Detail screen with the `SurveyModel` object
- [x] When we arrived at the Survey Detail screen, we will display the survey title and the survey description from the `SurveyModel` object, as well as load the background image using the URL from the `SurveyModel` object while calling get survey detail API through the view model (we will also show `LoadingIndicator` at this state)
- [x] Once the API call is done
  - If the API call return Success, we will replace the survey description text with the `text` of the `question` with `displayType == intro` (intro question) from `SurveyDetailModel`, furthermore, we will load the background image from the intro question's `coverImageUrl` and set the opacity of the background image with the value from the `coverImageOpacity` attribute
  - If the API call return Failed, we will show the error message through a SnackBar
- [x] When tapping on the "Start Survey" button
  - If there's a `SurveyDetailModel` from API, we will navigate to the Questions screen
  - If there's no `SurveyDetailModel` (get surveys detail API call returns Failed), we will call get survey detail API again
- [x] Add unit tests for `SurveyDetailViewModel`
- [x] Refactor`LoginState`

## Insight 📝

- We also refactor the `DimmedBackgroundWidget` to accept the opacity value as well

## Proof Of Work 📹

https://user-images.githubusercontent.com/13492460/209568599-c5e74ea5-9c3f-42ba-a8a8-4138dd059368.mov
