### PR TITLE
[#44] Implement backend for submit survey

### DIFF
--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -1,5 +1,6 @@
 import 'package:injectable/injectable.dart';
 import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/api/request/submit_survey_request.dart';
 import 'package:survey/api/service/survey_service.dart';
 import 'package:survey/constants.dart';
 import 'package:survey/database/hive_utils.dart';
@@ -14,6 +15,11 @@ abstract class SurveyRepository {
 
   Future<SurveyDetailModel> getSurveyDetail({
     required String surveyId,
+  });
+
+  Future<void> submitSurvey({
+    required String surveyId,
+    required List<SubmitSurveyQuestionRequest> questions,
   });
 }
 
@@ -51,6 +57,21 @@ class SurveyRepositoryImpl extends SurveyRepository {
     try {
       final response = await _surveyService.getSurveyDetail(surveyId);
       return SurveyDetailModel.fromResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<void> submitSurvey({
+    required String surveyId,
+    required List<SubmitSurveyQuestionRequest> questions,
+  }) async {
+    try {
+      return await _surveyService.submitSurvey(SubmitSurveyRequest(
+        surveyId: surveyId,
+        questions: questions,
+      ));
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/request/submit_survey_request.dart
+++ b/lib/api/request/submit_survey_request.dart
@@ -1,0 +1,51 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'submit_survey_request.g.dart';
+
+@JsonSerializable()
+class SubmitSurveyRequest {
+  final String surveyId;
+  final List<SubmitSurveyQuestionRequest> questions;
+
+  SubmitSurveyRequest({
+    required this.surveyId,
+    required this.questions,
+  });
+
+  factory SubmitSurveyRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubmitSurveyRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitSurveyRequestToJson(this);
+}
+
+@JsonSerializable()
+class SubmitSurveyQuestionRequest {
+  final String id;
+  final List<SubmitSurveyAnswerRequest> answers;
+
+  SubmitSurveyQuestionRequest({
+    required this.id,
+    required this.answers,
+  });
+
+  factory SubmitSurveyQuestionRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubmitSurveyQuestionRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitSurveyQuestionRequestToJson(this);
+}
+
+@JsonSerializable()
+class SubmitSurveyAnswerRequest {
+  final String id;
+  final String answer;
+
+  SubmitSurveyAnswerRequest({
+    required this.id,
+    required this.answer,
+  });
+
+  factory SubmitSurveyAnswerRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubmitSurveyAnswerRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitSurveyAnswerRequestToJson(this);
+}

--- a/lib/api/service/survey_service.dart
+++ b/lib/api/service/survey_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
+import 'package:survey/api/request/submit_survey_request.dart';
 import 'package:survey/api/response/survey_detail_response.dart';
 import 'package:survey/api/response/surveys_response.dart';
 
@@ -19,4 +20,7 @@ abstract class SurveyService {
   Future<SurveyDetailResponse> getSurveyDetail(
     @Path('surveyId') String surveyId,
   );
+
+  @POST('/api/v1/responses')
+  Future<void> submitSurvey(@Body() SubmitSurveyRequest body);
 }

--- a/lib/usecase/submit_survey_use_case.dart
+++ b/lib/usecase/submit_survey_use_case.dart
@@ -1,0 +1,32 @@
+import 'package:injectable/injectable.dart';
+import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/api/repository/survey_repository.dart';
+import 'package:survey/api/request/submit_survey_request.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+
+class SubmitSurveyInput {
+  String surveyId;
+  List<SubmitSurveyQuestionRequest> questions;
+
+  SubmitSurveyInput({
+    required this.surveyId,
+    required this.questions,
+  });
+}
+
+@Injectable()
+class SubmitSurveyUseCase extends UseCase<void, SubmitSurveyInput> {
+  final SurveyRepository _repository;
+
+  const SubmitSurveyUseCase(this._repository);
+
+  @override
+  Future<Result<void>> call(SubmitSurveyInput input) {
+    return _repository
+        .submitSurvey(surveyId: input.surveyId, questions: input.questions)
+        // ignore: unnecessary_cast
+        .then((value) => Success(null) as Result<void>)
+        .onError<NetworkExceptions>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+}

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -92,5 +92,22 @@ void main() {
 
       expect(result, throwsA(isA<NetworkExceptions>()));
     });
+
+    test('When calling submit survey successfully, it returns empty result',
+        () async {
+      when(mockSurveyService.submitSurvey(any)).thenAnswer((_) async => null);
+
+      await repository.submitSurvey(surveyId: 'surveyId', questions: []);
+    });
+
+    test(
+        'When calling submit survey failed, it returns NetworkExceptions error',
+        () async {
+      when(mockSurveyService.submitSurvey(any)).thenThrow(MockDioError());
+
+      result() => repository.submitSurvey(surveyId: 'surveyId', questions: []);
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
   });
 }

--- a/test/usecase/submit_survey_use_case_test.dart
+++ b/test/usecase/submit_survey_use_case_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey/api/exception/network_exceptions.dart';
+import 'package:survey/usecase/base/base_use_case.dart';
+import 'package:survey/usecase/submit_survey_use_case.dart';
+
+import '../../test/mock/mock_dependencies.mocks.dart';
+
+void main() {
+  group('SubmitSurveyUseCaseTest', () {
+    late MockSurveyRepository mockRepository;
+    late SubmitSurveyUseCase useCase;
+
+    final submitSurveyInput = SubmitSurveyInput(
+      surveyId: 'surveyId',
+      questions: [],
+    );
+
+    setUp(() {
+      mockRepository = MockSurveyRepository();
+      useCase = SubmitSurveyUseCase(mockRepository);
+    });
+
+    test(
+        'When executing use case and repository returns success, it returns Success result',
+        () async {
+      when(mockRepository.submitSurvey(
+        surveyId: submitSurveyInput.surveyId,
+        questions: submitSurveyInput.questions,
+      )).thenAnswer((_) async => null);
+
+      final result = await useCase.call(submitSurveyInput);
+
+      expect(result, isA<Success>());
+    });
+
+    test(
+        'When executing use case and repository returns error, it returns Failed result',
+        () async {
+      final exception = NetworkExceptions.badRequest();
+      when(mockRepository.submitSurvey(
+        surveyId: submitSurveyInput.surveyId,
+        questions: submitSurveyInput.questions,
+      )).thenAnswer((_) => Future.error(exception));
+
+      final result = await useCase.call(submitSurveyInput);
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}


### PR DESCRIPTION
#44

## What happened 👀

- [x] Create `SubmitSurveyRequest`
- [x] Add submit survey API call in service
- [x] Add submit survey service call in repository and add corresponding unit tests
- [x] Create `SubmitSurveyUseCase` and corresponding unit tests

## Insight 📝

N/A

## Proof Of Work 📹

```
flutter: *** Request ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/responses
flutter: method: POST
flutter: responseType: ResponseType.json
flutter: followRedirects: true
flutter: connectTimeout: 30000
flutter: sendTimeout: 0
flutter: receiveTimeout: 30000
flutter: receiveDataWhenStatusError: true
flutter: extra: {}
flutter: headers:
flutter:  content-type: application/json; charset=utf-8
flutter:  Authorization: Bearer 4HOtnPBTBzXsspCJTo5pNS1XQH81tEbtLwG-3epV480
flutter: data:
flutter: {survey_id: 270130035d415c1d90bb, questions: [Instance of 'SubmitSurveyQuestionRequest', Instance of 'SubmitSurveyQuestionRequest']}
flutter:
flutter: *** Response ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/responses
flutter: statusCode: 201
flutter: headers:
flutter:  connection: keep-alive
flutter:  cache-control: max-age=0, private, must-revalidate
flutter:  transfer-encoding: chunked
flutter:  date: Mon, 26 Dec 2022 16:49:22 GMT
flutter:  vary: Accept-Encoding, Origin
flutter:  content-encoding: gzip
flutter:  strict-transport-security: max-age=31536000; includeSubDomains
flutter:  referrer-policy: strict-origin-when-cross-origin
flutter:  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=s%2BsrZUtRe37eDgr7fcFhkC9OjDcWaH8kA5m4QbRl%2BA%2F%2BGIT4pgnIs6b%2F%2Ba6Nqax7qfzkIFkRL33xM3lHlQKOukAsMYMCmaCMdOfq547cwTwNpWilG3MSy%2BHDjMTHuLB5Qg6hloQWkZec"}],"group":"cf-nel","max_age":604800}
flutter:  cf-cache-status: DYNAMIC
flutter:  x-permitted-cross-domain-policies: none
flutter:  content-type: application/json; charset=utf-8
flutter:  x-xss-protection: 1; mode=block
flutter:  server: cloudflare
flutter:  x-request-id: 6daf25f3-bfd5-4d64-a6c9-c52ee68c9e24
flutter:  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
flutter:  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
flutter:  x-download-options: noopen
flutter:  cf-ray: 77fb4f2c78f65bff-BKK
flutter:  x-runtime: 0.019235
flutter:  etag: W/"a158a8d8704157d869a7b89afd82ecd5"
flutter:  via: 1.1 vegur
flutter:  x-frame-options: SAMEORIGIN
flutter:  x-content-type-options: nosniff
flutter: Response Text:
flutter: {}
flutter:
```
