### PR TITLE
[#107] Write integration tests for Reset Password page

### DIFF
--- a/integration_test/fake_service/fake_auth_service.dart
+++ b/integration_test/fake_service/fake_auth_service.dart
@@ -1,20 +1,31 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:survey/api/request/login_request.dart';
+import 'package:survey/api/request/reset_password_request.dart';
 import 'package:survey/api/response/token_response.dart';
 import 'package:survey/api/service/auth_service.dart';
 
 import 'fake_data.dart';
 
 const loginKey = 'login';
+const resetPasswordKey = 'resetPassword';
 
 class FakeAuthService extends Fake implements AuthService {
   @override
   Future<TokenResponse> login(LoginRequest body) async {
     final response = FakeData.fakeResponses[loginKey]!;
 
-    if (response.statusCode != 200) {
+    if (response.statusCode != successStatusCode) {
       throw fakeDioError(response.statusCode);
     }
     return TokenResponse.fromJson(response.json);
+  }
+
+  @override
+  Future<void> resetPassword(ResetPasswordRequest body) async {
+    final response = FakeData.fakeResponses[resetPasswordKey]!;
+
+    if (response.statusCode != successStatusCode) {
+      throw fakeDioError(response.statusCode);
+    }
   }
 }

--- a/integration_test/fake_service/fake_data.dart
+++ b/integration_test/fake_service/fake_data.dart
@@ -1,5 +1,8 @@
 import 'package:dio/dio.dart';
 
+const successStatusCode = 200;
+const _errorStatusCode = 400;
+
 class FakeResponse {
   final int statusCode;
   final Map<String, dynamic> json;
@@ -13,13 +16,13 @@ class FakeData {
   static Map<String, FakeResponse> fakeResponses = {};
 
   static void addSuccessResponse(String key, Map<String, dynamic> response) {
-    final newResponse = FakeResponse(200, response);
+    final newResponse = FakeResponse(successStatusCode, response);
     fakeResponses.update(key, (response) => newResponse,
         ifAbsent: () => newResponse);
   }
 
   static void addErrorResponse(String key) {
-    final newResponse = FakeResponse(400, {});
+    final newResponse = FakeResponse(_errorStatusCode, {});
     fakeResponses.update(key, (response) => newResponse,
         ifAbsent: () => newResponse);
   }

--- a/integration_test/login_page_test.dart
+++ b/integration_test/login_page_test.dart
@@ -82,7 +82,7 @@ void main() {
     });
 
     testWidgets(
-        'When logging in fails, it shows the corresponding error message',
+        'When logging in failed, it shows the corresponding error message',
         (WidgetTester tester) async {
       FakeData.addErrorResponse(loginKey);
       await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(LoginPage()));

--- a/integration_test/reset_password_page_test.dart
+++ b/integration_test/reset_password_page_test.dart
@@ -1,0 +1,123 @@
+import 'package:another_flushbar/flushbar.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:survey/navigator.dart';
+import 'package:survey/page/login/login_page.dart';
+import 'package:survey/page/login/login_page_key.dart';
+import 'package:survey/page/resetpassword/reset_password_page.dart';
+import 'package:survey/page/resetpassword/reset_password_page_key.dart';
+
+import 'fake_service/fake_auth_service.dart';
+import 'fake_service/fake_data.dart';
+import 'utils/integration_test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ResetPasswordPageTest', () {
+    late Finder abbbResetPassword;
+    late Finder sltiResetPasswordEmail;
+    late Finder rbResetPassword;
+    late Finder tbLoginForgotPassword;
+
+    setUpAll(() async {
+      await IntegrationTestUtils.prepareTestEnvVariables();
+    });
+
+    setUp(() async {
+      abbbResetPassword = find.byKey(ResetPasswordPageKey.abbbResetPassword);
+      sltiResetPasswordEmail =
+          find.byKey(ResetPasswordPageKey.sltiResetPasswordEmail);
+      rbResetPassword = find.byKey(ResetPasswordPageKey.rbResetPassword);
+      tbLoginForgotPassword = find.byKey(LoginPageKey.tbLoginForgotPassword);
+    });
+
+    testWidgets('When starting, it shows the Reset Password page correctly',
+        (WidgetTester tester) async {
+      await tester
+          .pumpWidget(IntegrationTestUtils.prepareTestApp(ResetPasswordPage()));
+
+      await tester.pumpAndSettle();
+      expect(abbbResetPassword, findsOneWidget);
+      expect(sltiResetPasswordEmail, findsOneWidget);
+      expect(rbResetPassword, findsOneWidget);
+    });
+
+    testWidgets(
+        'When resetting password successfully, it shows the success Flushbar',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(resetPasswordKey, {});
+      await tester
+          .pumpWidget(IntegrationTestUtils.prepareTestApp(ResetPasswordPage()));
+
+      await tester.pumpAndSettle();
+      await tester.enterText(sltiResetPasswordEmail, 'chorny@berlento.com');
+      await tester.tap(rbResetPassword);
+
+      // Wait for Flushbar animation
+      await tester.pump(Duration(milliseconds: 500));
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Flushbar &&
+              ((widget.titleText as Text).data == 'Check your email.' ||
+                  (widget.titleText as Text).data == 'ตรวจสอบอีเมลล์ของคุณ')),
+          findsOneWidget);
+    });
+
+    testWidgets(
+        'When resetting password with invalid email, it shows the corresponding error message',
+        (WidgetTester tester) async {
+      await tester
+          .pumpWidget(IntegrationTestUtils.prepareTestApp(ResetPasswordPage()));
+
+      await tester.pumpAndSettle();
+      await tester.enterText(sltiResetPasswordEmail, 'chorny');
+      await tester.tap(rbResetPassword);
+
+      await tester.pumpAndSettle();
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Text &&
+              (widget.data == 'Invalid email' ||
+                  widget.data == 'อีเมลล์ไม่ถูกต้อง')),
+          findsOneWidget);
+    });
+
+    testWidgets(
+        'When resetting password failed, it shows the corresponding error message',
+        (WidgetTester tester) async {
+      FakeData.addErrorResponse(resetPasswordKey);
+      await tester
+          .pumpWidget(IntegrationTestUtils.prepareTestApp(ResetPasswordPage()));
+
+      await tester.pumpAndSettle();
+      await tester.enterText(sltiResetPasswordEmail, 'chorny@berlento.com');
+      await tester.tap(rbResetPassword);
+
+      await tester.pumpAndSettle();
+      expect(find.text('Bad request'), findsOneWidget);
+    });
+
+    testWidgets(
+        'When tapping on the app bar back button, it navigates back to the Login page',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(
+        LoginPage(),
+        routes: <String, WidgetBuilder>{
+          routeResetPassword: (BuildContext context) =>
+              const ResetPasswordPage()
+        },
+      ));
+
+      await tester.pumpAndSettle();
+      await tester.tap(tbLoginForgotPassword);
+
+      await tester.pumpAndSettle();
+      await tester.tap(abbbResetPassword);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(LoginPage), findsOneWidget);
+    });
+  });
+}

--- a/lib/page/home/home_page.dart
+++ b/lib/page/home/home_page.dart
@@ -65,11 +65,8 @@ class _HomePageState extends ConsumerState<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<HomeState>(homeViewModelProvider, (
-      HomeState? previousState,
-      HomeState newState,
-    ) {
-      newState.maybeWhen(
+    ref.listen<HomeState>(homeViewModelProvider, (_, state) {
+      state.maybeWhen(
         logoutSuccess: () =>
             _appNavigator.navigateToStartAndClearStack(context),
         orElse: () {},

--- a/lib/page/login/login_page.dart
+++ b/lib/page/login/login_page.dart
@@ -36,11 +36,8 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<LoginState>(loginViewModelProvider, (
-      LoginState? previousLoginState,
-      LoginState newLoginState,
-    ) {
-      newLoginState.maybeWhen(
+    ref.listen<LoginState>(loginViewModelProvider, (_, state) {
+      state.maybeWhen(
         success: () => _navigateToHome(),
         apiError: (errorMessage) => _showError(errorMessage),
         invalidInputsError: () =>

--- a/lib/page/questions/questions_page.dart
+++ b/lib/page/questions/questions_page.dart
@@ -47,11 +47,8 @@ class _QuestionsPageState extends ConsumerState<QuestionsPage> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<QuestionsState>(questionsViewModelProvider, (
-      QuestionsState? previousState,
-      QuestionsState newState,
-    ) {
-      newState.maybeWhen(
+    ref.listen<QuestionsState>(questionsViewModelProvider, (_, state) {
+      state.maybeWhen(
         submitSurveySuccess: (outroMessage) =>
             _appNavigator.navigateToCompletion(context, outroMessage),
         orElse: () {},

--- a/lib/page/resetpassword/reset_password_page.dart
+++ b/lib/page/resetpassword/reset_password_page.dart
@@ -6,6 +6,7 @@ import 'package:survey/constants.dart';
 import 'package:survey/di/di.dart';
 import 'package:survey/gen/assets.gen.dart';
 import 'package:survey/gen/colors.gen.dart';
+import 'package:survey/page/resetpassword/reset_password_page_key.dart';
 import 'package:survey/page/resetpassword/reset_password_state.dart';
 import 'package:survey/page/resetpassword/reset_password_view_model.dart';
 import 'package:survey/resource/dimens.dart';
@@ -33,11 +34,8 @@ class _ResetPasswordPageState extends ConsumerState<ResetPasswordPage> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<ResetPasswordState>(resetPasswordViewModelProvider, (
-      ResetPasswordState? previousState,
-      ResetPasswordState newState,
-    ) {
-      newState.maybeWhen(
+    ref.listen<ResetPasswordState>(resetPasswordViewModelProvider, (_, state) {
+      state.maybeWhen(
         success: () => _showResetPasswordSuccessFlushbar(),
         apiError: (errorMessage) => _showError(errorMessage),
         invalidInputError: () =>
@@ -71,6 +69,7 @@ class _ResetPasswordPageState extends ConsumerState<ResetPasswordPage> {
                   ),
                   const SizedBox(height: Dimens.space96),
                   SingleLineTextInputWidget(
+                    key: ResetPasswordPageKey.sltiResetPasswordEmail,
                     hintText: AppLocalizations.of(context)!.email,
                     textInputAction: TextInputAction.done,
                     controller: _emailController,
@@ -78,6 +77,7 @@ class _ResetPasswordPageState extends ConsumerState<ResetPasswordPage> {
                   ),
                   const SizedBox(height: Dimens.space20),
                   RoundedButtonWidget(
+                    key: ResetPasswordPageKey.rbResetPassword,
                     buttonText:
                         AppLocalizations.of(context)!.resetPasswordReset,
                     onPressed: () {
@@ -98,7 +98,9 @@ class _ResetPasswordPageState extends ConsumerState<ResetPasswordPage> {
                 top: Dimens.space24,
                 left: Dimens.space22,
               ),
-              child: AppBarBackButtonWidget(),
+              child: AppBarBackButtonWidget(
+                key: ResetPasswordPageKey.abbbResetPassword,
+              ),
             ),
           ),
           ref.watch(resetPasswordViewModelProvider).maybeWhen(

--- a/lib/page/resetpassword/reset_password_page_key.dart
+++ b/lib/page/resetpassword/reset_password_page_key.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class ResetPasswordPageKey {
+  ResetPasswordPageKey._();
+
+  static final abbbResetPassword = Key('abbbResetPassword');
+  static final sltiResetPasswordEmail = Key('sltiResetPasswordEmail');
+  static final rbResetPassword = Key('rbResetPassword');
+}

--- a/lib/page/surveydetail/survey_detail_page.dart
+++ b/lib/page/surveydetail/survey_detail_page.dart
@@ -54,11 +54,8 @@ class _SurveyDetailPageState extends ConsumerState<SurveyDetailPage> {
     final survey = ref.watch(_surveyStreamProvider).value;
     final surveyDetail = ref.watch(_surveyDetailStreamProvider).value;
 
-    ref.listen<SurveyDetailState>(surveyDetailViewModelProvider, (
-      SurveyDetailState? previousState,
-      SurveyDetailState newState,
-    ) {
-      newState.maybeWhen(
+    ref.listen<SurveyDetailState>(surveyDetailViewModelProvider, (_, state) {
+      state.maybeWhen(
         retrySuccess: (surveyDetail) => _navigateToQuestions(surveyDetail),
         orElse: () {},
       );


### PR DESCRIPTION
#107

## What happened 👀

Write integration tests for the Reset Password page
- [x] Create and bind keys to each widget
- [x] Add mock reset password function to a service
- [x] Create the test file and write the integration test functions

Refactorations
- [x] Rename unused `previousState` variables to `_` to solve [this comment](https://github.com/chornerman/Survey/pull/81#discussion_r1057432334)

## Insight 📝

- We can use the below command to run this test on an emulator:
```
fvm flutter drive --driver=integration_test_driver/integration_test_driver.dart --flavor staging --target=integration_test/reset_password_page_test.dart
```

## Proof Of Work 📹

All tests passed!

https://user-images.githubusercontent.com/13492460/212464316-e47b6708-c0eb-4f52-8c27-fde59859aa3e.mov
