### PR TITLE
[#109] Write integration tests for Home page

### DIFF
--- a/integration_test/fake_service/fake_survey_service.dart
+++ b/integration_test/fake_service/fake_survey_service.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey/api/request/submit_survey_request.dart';
+import 'package:survey/api/response/survey_detail_response.dart';
+import 'package:survey/api/response/surveys_response.dart';
+import 'package:survey/api/service/survey_service.dart';
+
+import 'fake_data.dart';
+
+const getSurveysKey = 'getSurveys';
+const getSurveyDetailKey = 'getSurveyDetail';
+const submitSurveyKey = 'submitSurvey';
+
+class FakeSurveyService extends Fake implements SurveyService {
+  @override
+  Future<SurveysResponse> getSurveys(int pageNumber, int pageSize) async {
+    final response = FakeData.fakeResponses[getSurveysKey]!;
+
+    if (response.statusCode != successStatusCode) {
+      throw fakeDioError(response.statusCode);
+    }
+    return SurveysResponse.fromJson(response.json);
+  }
+
+  @override
+  Future<SurveyDetailResponse> getSurveyDetail(String surveyId) async {
+    final response = FakeData.fakeResponses[getSurveyDetailKey]!;
+
+    if (response.statusCode != successStatusCode) {
+      throw fakeDioError(response.statusCode);
+    }
+    return SurveyDetailResponse.fromJson(response.json);
+  }
+
+  @override
+  Future<void> submitSurvey(SubmitSurveyRequest body) async {
+    final response = FakeData.fakeResponses[submitSurveyKey]!;
+
+    if (response.statusCode != successStatusCode) {
+      throw fakeDioError(response.statusCode);
+    }
+  }
+}

--- a/integration_test/fake_service/fake_user_service.dart
+++ b/integration_test/fake_service/fake_user_service.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey/api/response/user_response.dart';
+import 'package:survey/api/service/user_service.dart';
+
+import 'fake_data.dart';
+
+const getUserKey = 'getUser';
+
+class FakeUserService extends Fake implements UserService {
+  @override
+  Future<UserResponse> getUser() async {
+    final response = FakeData.fakeResponses[getUserKey]!;
+
+    if (response.statusCode != successStatusCode) {
+      throw fakeDioError(response.statusCode);
+    }
+    return UserResponse.fromJson(response.json);
+  }
+}

--- a/integration_test/home_page_test.dart
+++ b/integration_test/home_page_test.dart
@@ -1,0 +1,133 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:intl/intl.dart';
+import 'package:survey/navigator.dart';
+import 'package:survey/page/home/home_page.dart';
+import 'package:survey/page/home/home_page_key.dart';
+import 'package:survey/page/home/home_view_model.dart';
+import 'package:survey/page/surveydetail/survey_detail_page.dart';
+
+import 'fake_service/fake_data.dart';
+import 'fake_service/fake_survey_service.dart';
+import 'fake_service/fake_user_service.dart';
+import 'utils/file_utils.dart';
+import 'utils/integration_test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('HomePageTest', () {
+    late Finder huaHome;
+    late Finder nbHomeTakeSurvey;
+
+    late Map<String, dynamic> surveysJson;
+    late Map<String, dynamic> userJson;
+
+    setUpAll(() async {
+      await IntegrationTestUtils.prepareTestEnvVariables();
+    });
+
+    setUp(() async {
+      huaHome = find.byKey(HomePageKey.huaHome);
+      nbHomeTakeSurvey = find.byKey(HomePageKey.nbHomeTakeSurvey);
+
+      surveysJson = await FileUtils.loadFile('mock_response/surveys.json');
+      userJson = await FileUtils.loadFile('mock_response/user.json');
+    });
+
+    testWidgets('When starting, it shows date text correctly',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(HomePage()));
+
+      await tester.pumpAndSettle();
+      expect(
+          find.text(DateFormat(homeCurrentDatePattern)
+              .format(clock.now())
+              .toUpperCase()),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Text &&
+              (widget.data == 'Today' || widget.data == 'วันนี้')),
+          findsOneWidget);
+    });
+
+    testWidgets('When loading surveys successfully, it shows surveys correctly',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(getSurveysKey, surveysJson);
+      FakeData.addSuccessResponse(getUserKey, userJson);
+      await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(HomePage()));
+
+      await tester.pumpAndSettle();
+      // Verify first survey page
+      final survey1 = surveysJson['data'][0];
+      expect(find.text(survey1['title']), findsOneWidget);
+      expect(find.text(survey1['description']), findsOneWidget);
+
+      // Swipe to next page
+      await tester.flingFrom(Offset(100, 300), Offset(-100, 0), 500);
+
+      await tester.pumpAndSettle();
+      // Verify second survey page
+      final survey2 = surveysJson['data'][1];
+      expect(find.text(survey2['title']), findsOneWidget);
+      expect(find.text(survey2['description']), findsOneWidget);
+    });
+
+    testWidgets(
+        'When loading surveys failed, it shows the corresponding error message',
+        (WidgetTester tester) async {
+      FakeData.addErrorResponse(getSurveysKey);
+      FakeData.addSuccessResponse(getUserKey, userJson);
+      await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(HomePage()));
+
+      await tester.pumpAndSettle();
+      expect(find.text('Bad request'), findsOneWidget);
+    });
+
+    testWidgets(
+        'When getting user failed, it shows the corresponding error message',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(getSurveysKey, surveysJson);
+      FakeData.addErrorResponse(getUserKey);
+      await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(HomePage()));
+
+      await tester.pumpAndSettle();
+      expect(find.text('Bad request'), findsOneWidget);
+    });
+
+    testWidgets(
+        'When tapping on the user avatar, it opens the drawer with correct user name',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(getUserKey, userJson);
+      await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(HomePage()));
+
+      await tester.pumpAndSettle();
+      await tester.tap(huaHome);
+
+      await tester.pumpAndSettle();
+      expect(find.text(userJson['data']['name']), findsOneWidget);
+    });
+
+    testWidgets(
+        'When tapping on Take Survey button, it navigates to Survey Detail page',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(getSurveysKey, surveysJson);
+      FakeData.addSuccessResponse(getUserKey, userJson);
+      await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(
+        HomePage(),
+        routes: <String, WidgetBuilder>{
+          routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
+        },
+      ));
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(SurveyDetailPage), findsOneWidget);
+    });
+  });
+}

--- a/integration_test/login_page_test.dart
+++ b/integration_test/login_page_test.dart
@@ -97,7 +97,7 @@ void main() {
     });
 
     testWidgets(
-        'When tapping on forgot password, it navigates to Reset Password page',
+        'When tapping on Forgot Password button, it navigates to Reset Password page',
         (WidgetTester tester) async {
       await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(
         LoginPage(),

--- a/integration_test/utils/integration_test_utils.dart
+++ b/integration_test/utils/integration_test_utils.dart
@@ -3,11 +3,15 @@ import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:survey/api/service/auth_service.dart';
+import 'package:survey/api/service/survey_service.dart';
+import 'package:survey/api/service/user_service.dart';
 import 'package:survey/database/hive.dart';
 import 'package:survey/di/di.dart';
 import 'package:survey/resource/app_theme.dart';
 
 import '../fake_service/fake_auth_service.dart';
+import '../fake_service/fake_survey_service.dart';
+import '../fake_service/fake_user_service.dart';
 
 class IntegrationTestUtils {
   IntegrationTestUtils._();
@@ -39,5 +43,7 @@ class IntegrationTestUtils {
 
     getIt.allowReassignment = true;
     getIt.registerSingleton<AuthService>(FakeAuthService());
+    getIt.registerSingleton<SurveyService>(FakeSurveyService());
+    getIt.registerSingleton<UserService>(FakeUserService());
   }
 }

--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -24,7 +24,7 @@ abstract class SurveyRepository {
   });
 }
 
-@Singleton(as: SurveyRepository)
+@LazySingleton(as: SurveyRepository)
 class SurveyRepositoryImpl extends SurveyRepository {
   final SurveyService _surveyService;
   final HiveUtils _hiveUtils;

--- a/lib/api/repository/user_repository.dart
+++ b/lib/api/repository/user_repository.dart
@@ -7,7 +7,7 @@ abstract class UserRepository {
   Future<UserModel> getUser();
 }
 
-@Singleton(as: UserRepository)
+@LazySingleton(as: UserRepository)
 class UserRepositoryImpl extends UserRepository {
   final UserService _userService;
 

--- a/lib/api/service/survey_service.dart
+++ b/lib/api/service/survey_service.dart
@@ -6,9 +6,22 @@ import 'package:survey/api/response/surveys_response.dart';
 
 part 'survey_service.g.dart';
 
-@RestApi()
 abstract class SurveyService {
-  factory SurveyService(Dio dio, {String baseUrl}) = _SurveyService;
+  Future<SurveysResponse> getSurveys(
+    @Path('pageNumber') int pageNumber,
+    @Path('pageSize') int pageSize,
+  );
+
+  Future<SurveyDetailResponse> getSurveyDetail(
+    @Path('surveyId') String surveyId,
+  );
+
+  Future<void> submitSurvey(@Body() SubmitSurveyRequest body);
+}
+
+@RestApi()
+abstract class SurveyServiceImpl extends SurveyService {
+  factory SurveyServiceImpl(Dio dio, {String baseUrl}) = _SurveyServiceImpl;
 
   @GET('/api/v1/surveys?page[number]={pageNumber}&page[size]={pageSize}')
   Future<SurveysResponse> getSurveys(

--- a/lib/api/service/user_service.dart
+++ b/lib/api/service/user_service.dart
@@ -4,9 +4,13 @@ import 'package:survey/api/response/user_response.dart';
 
 part 'user_service.g.dart';
 
-@RestApi()
 abstract class UserService {
-  factory UserService(Dio dio, {String baseUrl}) = _UserService;
+  Future<UserResponse> getUser();
+}
+
+@RestApi()
+abstract class UserServiceImpl extends UserService {
+  factory UserServiceImpl(Dio dio, {String baseUrl}) = _UserServiceImpl;
 
   @GET('/api/v1/me')
   Future<UserResponse> getUser();

--- a/lib/di/module/service_module.dart
+++ b/lib/di/module/service_module.dart
@@ -15,17 +15,17 @@ abstract class ServiceModule {
     );
   }
 
-  @Singleton()
-  SurveyService provideSurveyService(DioProvider dioProvider) {
-    return SurveyService(
+  @Singleton(as: SurveyService)
+  SurveyServiceImpl provideSurveyService(DioProvider dioProvider) {
+    return SurveyServiceImpl(
       dioProvider.getAuthenticatedDio(),
       baseUrl: EnvVariables.apiEndpoint,
     );
   }
 
-  @Singleton()
-  UserService provideUserService(DioProvider dioProvider) {
-    return UserService(
+  @Singleton(as: UserService)
+  UserServiceImpl provideUserService(DioProvider dioProvider) {
+    return UserServiceImpl(
       dioProvider.getAuthenticatedDio(),
       baseUrl: EnvVariables.apiEndpoint,
     );

--- a/lib/navigator.dart
+++ b/lib/navigator.dart
@@ -12,7 +12,7 @@ import 'package:survey/page/surveydetail/survey_detail_page.dart';
 const String _routeStart = '/';
 const String routeHome = '/home';
 const String routeResetPassword = '/reset-password';
-const String _routeSurveyDetail = '/survey-detail';
+const String routeSurveyDetail = '/survey-detail';
 const String _routeQuestions = '/questions';
 const String _routeCompletion = '/completion';
 
@@ -21,7 +21,7 @@ class Routes {
     _routeStart: (BuildContext context) => StartPage(),
     routeHome: (BuildContext context) => const HomePage(),
     routeResetPassword: (BuildContext context) => const ResetPasswordPage(),
-    _routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
+    routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
     _routeQuestions: (BuildContext context) => const QuestionsPage(),
     _routeCompletion: (BuildContext context) => const CompletionPage(),
   };
@@ -65,10 +65,7 @@ class AppNavigatorImpl extends AppNavigator {
 
   @override
   void navigateToSurveyDetail(BuildContext context, SurveyModel survey) =>
-      Navigator.of(context).pushNamed(
-        _routeSurveyDetail,
-        arguments: survey,
-      );
+      Navigator.of(context).pushNamed(routeSurveyDetail, arguments: survey);
 
   @override
   void navigateToQuestions(

--- a/lib/page/home/home_page_key.dart
+++ b/lib/page/home/home_page_key.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class HomePageKey {
+  HomePageKey._();
+
+  static final huaHome = Key('huaHome');
+  static final nbHomeTakeSurvey = Key('nbHomeTakeSurvey');
+}

--- a/lib/page/home/home_view_model.dart
+++ b/lib/page/home/home_view_model.dart
@@ -13,7 +13,7 @@ import 'package:survey/usecase/get_surveys_use_case.dart';
 import 'package:survey/usecase/get_user_use_case.dart';
 import 'package:survey/usecase/logout_use_case.dart';
 
-const _homeCurrentDatePattern = 'EEEE, MMMM dd';
+const homeCurrentDatePattern = 'EEEE, MMMM dd';
 const _surveysPageSize = 5;
 
 class HomeViewModel extends StateNotifier<HomeState> {
@@ -117,7 +117,7 @@ class HomeViewModel extends StateNotifier<HomeState> {
   }
 
   String getCurrentDate() =>
-      DateFormat(_homeCurrentDatePattern).format(clock.now()).toUpperCase();
+      DateFormat(homeCurrentDatePattern).format(clock.now()).toUpperCase();
 
   void clearError() {
     _error.add(null);

--- a/lib/page/home/widget/home_header_widget.dart
+++ b/lib/page/home/widget/home_header_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:survey/page/home/home_page_key.dart';
 import 'package:survey/page/home/widget/home_user_avatar_widget.dart';
 import 'package:survey/resource/dimens.dart';
 
@@ -39,7 +40,10 @@ class HomeHeaderWidget extends StatelessWidget {
               const Expanded(child: const SizedBox.shrink()),
               GestureDetector(
                 onTap: () => Scaffold.of(context).openEndDrawer(),
-                child: HomeUserAvatarWidget(userAvatarUrl: userAvatarUrl),
+                child: HomeUserAvatarWidget(
+                  key: HomePageKey.huaHome,
+                  userAvatarUrl: userAvatarUrl,
+                ),
               ),
             ],
           ),

--- a/lib/page/home/widget/home_surveys_item_widget.dart
+++ b/lib/page/home/widget/home_surveys_item_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:survey/model/survey_model.dart';
+import 'package:survey/page/home/home_page_key.dart';
 import 'package:survey/resource/dimens.dart';
 import 'package:survey/widget/dimmed_background_widget.dart';
 import 'package:survey/widget/next_button_widget.dart';
@@ -54,7 +55,10 @@ class HomeSurveysItemWidget extends StatelessWidget {
                   ),
                   Padding(
                     padding: const EdgeInsets.only(left: Dimens.space20),
-                    child: NextButtonWidget(onPressed: onNextButtonPressed),
+                    child: NextButtonWidget(
+                      key: HomePageKey.nbHomeTakeSurvey,
+                      onPressed: onNextButtonPressed,
+                    ),
                   ),
                 ],
               )


### PR DESCRIPTION
#109

## What happened 👀

Write integration tests for the Home page
- [x] Create and bind keys to each widget
- [x] Create base abstract classes of `SurveyService` and `UserService`
- [x] Create `FakeSurveyService` and `FakeUserService`
- [x] Create the test file and write the integration test functions

## Insight 📝

- We need to use `@LazySingleton` annotation instead of `Singleton` for `SurveyRespoitory` and `UserRepository`
- We can use the below command to run this test on an emulator:
```
fvm flutter drive --driver=integration_test_driver/integration_test_driver.dart --flavor staging --target=integration_test/home_page_test.dart
```

## Proof Of Work 📹

All tests passed!

https://user-images.githubusercontent.com/13492460/212464426-d95c5747-1323-4519-afc8-cea85b4adbe2.mov
