### PR TITLE
[#110] Write integration tests for Survey Detail page

### DIFF
--- a/integration_test/survey_detail_page_test.dart
+++ b/integration_test/survey_detail_page_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:survey/navigator.dart';
+import 'package:survey/page/home/home_page.dart';
+import 'package:survey/page/home/home_page_key.dart';
+import 'package:survey/page/questions/questions_page.dart';
+import 'package:survey/page/surveydetail/survey_detail_page.dart';
+import 'package:survey/page/surveydetail/survey_detail_page_key.dart';
+
+import 'fake_service/fake_data.dart';
+import 'fake_service/fake_survey_service.dart';
+import 'fake_service/fake_user_service.dart';
+import 'utils/file_utils.dart';
+import 'utils/integration_test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SurveyDetailPageTest', () {
+    late Finder abbbSurveyDetail;
+    late Finder rbSurveyDetailStartSurvey;
+    late Finder nbHomeTakeSurvey;
+    late Widget homeWidget;
+
+    late Map<String, dynamic> surveyDetailJson;
+    late Map<String, dynamic> surveysJson;
+    late Map<String, dynamic> userJson;
+
+    setUpAll(() async {
+      await IntegrationTestUtils.prepareTestEnvVariables();
+    });
+
+    setUp(() async {
+      abbbSurveyDetail = find.byKey(SurveyDetailPageKey.abbbSurveyDetail);
+      rbSurveyDetailStartSurvey =
+          find.byKey(SurveyDetailPageKey.rbSurveyDetailStartSurvey);
+      nbHomeTakeSurvey = find.byKey(HomePageKey.nbHomeTakeSurvey);
+
+      homeWidget = IntegrationTestUtils.prepareTestApp(
+        HomePage(),
+        routes: <String, WidgetBuilder>{
+          routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
+          routeQuestions: (BuildContext context) => const QuestionsPage(),
+        },
+      );
+
+      surveyDetailJson =
+          await FileUtils.loadFile('mock_response/survey_detail.json');
+      surveysJson = await FileUtils.loadFile('mock_response/surveys.json');
+      userJson = await FileUtils.loadFile('mock_response/user.json');
+
+      FakeData.addSuccessResponse(getSurveysKey, surveysJson);
+      FakeData.addSuccessResponse(getUserKey, userJson);
+    });
+
+    testWidgets(
+        'When getting survey detail successfully, it shows survey detail correctly',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(getSurveyDetailKey, surveyDetailJson);
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      expect(find.text(surveysJson['data'][0]['title']), findsOneWidget);
+      expect(find.text(surveyDetailJson['data']['questions'][0]['text']),
+          findsOneWidget);
+    });
+
+    testWidgets(
+        'When getting survey detail failed, it shows the corresponding error message',
+        (WidgetTester tester) async {
+      FakeData.addErrorResponse(getSurveyDetailKey);
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      expect(find.text('Bad request'), findsOneWidget);
+    });
+
+    testWidgets(
+        'When tapping on Start Survey button, it navigates to Questions page',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(getSurveyDetailKey, surveyDetailJson);
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(rbSurveyDetailStartSurvey);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(QuestionsPage), findsOneWidget);
+    });
+
+    testWidgets(
+        'When tapping on the app bar back button, it navigates back to the Home page',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(abbbSurveyDetail);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(HomePage), findsOneWidget);
+    });
+  });
+}

--- a/lib/navigator.dart
+++ b/lib/navigator.dart
@@ -13,8 +13,8 @@ const String _routeStart = '/';
 const String routeHome = '/home';
 const String routeResetPassword = '/reset-password';
 const String routeSurveyDetail = '/survey-detail';
-const String _routeQuestions = '/questions';
-const String _routeCompletion = '/completion';
+const String routeQuestions = '/questions';
+const String routeCompletion = '/completion';
 
 class Routes {
   static final routes = <String, WidgetBuilder>{
@@ -22,8 +22,8 @@ class Routes {
     routeHome: (BuildContext context) => const HomePage(),
     routeResetPassword: (BuildContext context) => const ResetPasswordPage(),
     routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
-    _routeQuestions: (BuildContext context) => const QuestionsPage(),
-    _routeCompletion: (BuildContext context) => const CompletionPage(),
+    routeQuestions: (BuildContext context) => const QuestionsPage(),
+    routeCompletion: (BuildContext context) => const CompletionPage(),
   };
 }
 
@@ -74,7 +74,7 @@ class AppNavigatorImpl extends AppNavigator {
   ) =>
       Navigator.pushReplacementNamed(
         context,
-        _routeQuestions,
+        routeQuestions,
         arguments: surveyDetail,
       );
 
@@ -82,7 +82,7 @@ class AppNavigatorImpl extends AppNavigator {
   void navigateToCompletion(BuildContext context, String? outroMessage) =>
       Navigator.pushReplacementNamed(
         context,
-        _routeCompletion,
+        routeCompletion,
         arguments: outroMessage,
       );
 }

--- a/lib/page/surveydetail/survey_detail_page.dart
+++ b/lib/page/surveydetail/survey_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:survey/di/di.dart';
 import 'package:survey/model/survey_detail_model.dart';
 import 'package:survey/model/survey_model.dart';
 import 'package:survey/navigator.dart';
+import 'package:survey/page/surveydetail/survey_detail_page_key.dart';
 import 'package:survey/page/surveydetail/survey_detail_state.dart';
 import 'package:survey/page/surveydetail/survey_detail_view_model.dart';
 import 'package:survey/resource/dimens.dart';
@@ -106,7 +107,9 @@ class _SurveyDetailPageState extends ConsumerState<SurveyDetailPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  AppBarBackButtonWidget(),
+                  AppBarBackButtonWidget(
+                    key: SurveyDetailPageKey.abbbSurveyDetail,
+                  ),
                   const SizedBox(height: Dimens.space30),
                   Expanded(
                     child: SingleChildScrollView(
@@ -133,6 +136,7 @@ class _SurveyDetailPageState extends ConsumerState<SurveyDetailPage> {
                   Align(
                     alignment: Alignment.centerRight,
                     child: RoundedButtonWidget(
+                      key: SurveyDetailPageKey.rbSurveyDetailStartSurvey,
                       buttonText:
                           AppLocalizations.of(context)!.surveyDetailStartSurvey,
                       onPressed: () {

--- a/lib/page/surveydetail/survey_detail_page_key.dart
+++ b/lib/page/surveydetail/survey_detail_page_key.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class SurveyDetailPageKey {
+  SurveyDetailPageKey._();
+
+  static final abbbSurveyDetail = Key('abbbSurveyDetail');
+  static final rbSurveyDetailStartSurvey = Key('rbSurveyDetailStartSurvey');
+}


### PR DESCRIPTION
#110

## What happened 👀

Write integration tests for the Survey Detail page
- [x] Create and bind keys to each widget
- [x] Create the test file and write integration test functions

## Insight 📝

- We can use the below command to run this test on an emulator:
```
fvm flutter drive --driver=integration_test_driver/integration_test_driver.dart --flavor staging --target=integration_test/survey_detail_page_test.dart
```

## Proof Of Work 📹

All tests passed!

https://user-images.githubusercontent.com/13492460/212464583-a190342f-1244-45ba-baa9-d48c18d9951f.mov
