### PR TITLE
[#111] [#112] Write integration tests for take survey flow

### DIFF
--- a/integration_test/home_page_test.dart
+++ b/integration_test/home_page_test.dart
@@ -61,19 +61,17 @@ void main() {
       await tester.pumpWidget(IntegrationTestUtils.prepareTestApp(HomePage()));
 
       await tester.pumpAndSettle();
-      // Verify first survey page
-      final survey1 = surveysJson['data'][0];
-      expect(find.text(survey1['title']), findsOneWidget);
-      expect(find.text(survey1['description']), findsOneWidget);
+      final firstSurvey = surveysJson['data'][0];
+      expect(find.text(firstSurvey['title']), findsOneWidget);
+      expect(find.text(firstSurvey['description']), findsOneWidget);
 
       // Swipe to next page
       await tester.flingFrom(Offset(100, 300), Offset(-100, 0), 500);
 
       await tester.pumpAndSettle();
-      // Verify second survey page
-      final survey2 = surveysJson['data'][1];
-      expect(find.text(survey2['title']), findsOneWidget);
-      expect(find.text(survey2['description']), findsOneWidget);
+      final secondSurvey = surveysJson['data'][1];
+      expect(find.text(secondSurvey['title']), findsOneWidget);
+      expect(find.text(secondSurvey['description']), findsOneWidget);
     });
 
     testWidgets(

--- a/integration_test/survey_detail_page_test.dart
+++ b/integration_test/survey_detail_page_test.dart
@@ -64,9 +64,10 @@ void main() {
       await tester.tap(nbHomeTakeSurvey);
 
       await tester.pumpAndSettle();
-      expect(find.text(surveysJson['data'][0]['title']), findsOneWidget);
-      expect(find.text(surveyDetailJson['data']['questions'][0]['text']),
-          findsOneWidget);
+      final survey = surveysJson['data'][0];
+      expect(find.text(survey['title']), findsOneWidget);
+      final introQuestion = surveyDetailJson['data']['questions'][0];
+      expect(find.text(introQuestion['text']), findsOneWidget);
     });
 
     testWidgets(

--- a/integration_test/take_survey_flow_test.dart
+++ b/integration_test/take_survey_flow_test.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:survey/navigator.dart';
-import 'package:survey/page/completion/completion_page.dart';
 import 'package:survey/page/home/home_page.dart';
 import 'package:survey/page/home/home_page_key.dart';
 import 'package:survey/page/questions/questions_page.dart';
 import 'package:survey/page/questions/questions_page_key.dart';
 import 'package:survey/page/questions/widget/answer_widget.dart';
+import 'package:survey/page/surveycompletion/survey_completion_page.dart';
 import 'package:survey/page/surveydetail/survey_detail_page.dart';
 import 'package:survey/page/surveydetail/survey_detail_page_key.dart';
 
@@ -57,7 +57,8 @@ void main() {
         routes: <String, WidgetBuilder>{
           routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
           routeQuestions: (BuildContext context) => const QuestionsPage(),
-          routeCompletion: (BuildContext context) => const CompletionPage(),
+          routeSurveyCompletion: (BuildContext context) =>
+              const SurveyCompletionPage(),
         },
       );
 
@@ -88,7 +89,7 @@ void main() {
     });
 
     testWidgets(
-        'When answering all questions and submitting survey successfully, it navigates to Completion page then automatically returns to Home page',
+        'When answering all questions and submitting survey successfully, it navigates to Survey Completion page then automatically returns to Home page',
         (WidgetTester tester) async {
       FakeData.addSuccessResponse(submitSurveyKey, {});
       await tester.pumpWidget(homeWidget);
@@ -103,11 +104,11 @@ void main() {
           tester, nbQuestionsNext, rbQuestionsSubmitSurvey);
 
       await tester.pumpAndSettle();
-      expect(find.byType(CompletionPage), findsOneWidget);
+      expect(find.byType(SurveyCompletionPage), findsOneWidget);
       final outroQuestion = surveyDetailJson['data']['questions'][12];
       expect(find.text(outroQuestion['text']), findsOneWidget);
 
-      // Wait for the Completion page to close itself
+      // Wait for the Survey Completion page to close itself
       await tester.pump(Duration(milliseconds: 2500));
       expect(find.byType(HomePage), findsOneWidget);
     });

--- a/integration_test/take_survey_flow_test.dart
+++ b/integration_test/take_survey_flow_test.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:survey/navigator.dart';
+import 'package:survey/page/completion/completion_page.dart';
+import 'package:survey/page/home/home_page.dart';
+import 'package:survey/page/home/home_page_key.dart';
+import 'package:survey/page/questions/questions_page.dart';
+import 'package:survey/page/questions/questions_page_key.dart';
+import 'package:survey/page/questions/widget/answer_widget.dart';
+import 'package:survey/page/surveydetail/survey_detail_page.dart';
+import 'package:survey/page/surveydetail/survey_detail_page_key.dart';
+
+import 'fake_service/fake_data.dart';
+import 'fake_service/fake_survey_service.dart';
+import 'fake_service/fake_user_service.dart';
+import 'utils/file_utils.dart';
+import 'utils/integration_test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TakeSurveyFlowTest', () {
+    late Finder ibQuestionsQuitSurvey;
+    late Finder nbQuestionsNext;
+    late Finder rbQuestionsSubmitSurvey;
+    late Finder tbQuestionsQuitSurveyDialogPositive;
+    late Finder tbQuestionsQuitSurveyDialogNegative;
+    late Finder rbSurveyDetailStartSurvey;
+    late Finder nbHomeTakeSurvey;
+    late Widget homeWidget;
+
+    late Map<String, dynamic> surveyDetailJson;
+    late Map<String, dynamic> surveysJson;
+    late Map<String, dynamic> userJson;
+
+    setUpAll(() async {
+      await IntegrationTestUtils.prepareTestEnvVariables();
+    });
+
+    setUp(() async {
+      ibQuestionsQuitSurvey =
+          find.byKey(QuestionsPageKey.ibQuestionsQuitSurvey);
+      nbQuestionsNext = find.byKey(QuestionsPageKey.nbQuestionsNext);
+      rbQuestionsSubmitSurvey =
+          find.byKey(QuestionsPageKey.rbQuestionsSubmitSurvey);
+      tbQuestionsQuitSurveyDialogPositive =
+          find.byKey(QuestionsPageKey.tbQuestionsQuitSurveyDialogPositive);
+      tbQuestionsQuitSurveyDialogNegative =
+          find.byKey(QuestionsPageKey.tbQuestionsQuitSurveyDialogNegative);
+      rbSurveyDetailStartSurvey =
+          find.byKey(SurveyDetailPageKey.rbSurveyDetailStartSurvey);
+      nbHomeTakeSurvey = find.byKey(HomePageKey.nbHomeTakeSurvey);
+
+      homeWidget = IntegrationTestUtils.prepareTestApp(
+        HomePage(),
+        routes: <String, WidgetBuilder>{
+          routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
+          routeQuestions: (BuildContext context) => const QuestionsPage(),
+          routeCompletion: (BuildContext context) => const CompletionPage(),
+        },
+      );
+
+      surveyDetailJson =
+          await FileUtils.loadFile('mock_response/survey_detail.json');
+      surveysJson = await FileUtils.loadFile('mock_response/surveys.json');
+      userJson = await FileUtils.loadFile('mock_response/user.json');
+
+      FakeData.addSuccessResponse(getSurveyDetailKey, surveyDetailJson);
+      FakeData.addSuccessResponse(getSurveysKey, surveysJson);
+      FakeData.addSuccessResponse(getUserKey, userJson);
+    });
+
+    testWidgets('When starting, it shows questions correctly',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(rbSurveyDetailStartSurvey);
+
+      await tester.pumpAndSettle();
+      // Skip intro question
+      final firstQuestion = surveyDetailJson['data']['questions'][1];
+      expect(find.text(firstQuestion['text']), findsOneWidget);
+    });
+
+    testWidgets(
+        'When answering all questions and submitting survey successfully, it navigates to Completion page then automatically returns to Home page',
+        (WidgetTester tester) async {
+      FakeData.addSuccessResponse(submitSurveyKey, {});
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(rbSurveyDetailStartSurvey);
+
+      await _answerAllQuestions(
+          tester, nbQuestionsNext, rbQuestionsSubmitSurvey);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(CompletionPage), findsOneWidget);
+      final outroQuestion = surveyDetailJson['data']['questions'][12];
+      expect(find.text(outroQuestion['text']), findsOneWidget);
+
+      // Wait for the Completion page to close itself
+      await tester.pump(Duration(milliseconds: 2500));
+      expect(find.byType(HomePage), findsOneWidget);
+    });
+
+    testWidgets(
+        'When answering all questions and submitting survey failed, it shows the corresponding error message',
+        (WidgetTester tester) async {
+      FakeData.addErrorResponse(submitSurveyKey);
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(rbSurveyDetailStartSurvey);
+
+      await _answerAllQuestions(
+          tester, nbQuestionsNext, rbQuestionsSubmitSurvey);
+
+      await tester.pumpAndSettle();
+      expect(find.text('Bad request'), findsOneWidget);
+    });
+
+    testWidgets(
+        'When tapping on the Quit Survey dialog positive button, it navigates back to the Home page',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(rbSurveyDetailStartSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(ibQuestionsQuitSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(tbQuestionsQuitSurveyDialogPositive);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(HomePage), findsOneWidget);
+    });
+
+    testWidgets(
+        'When tapping on the Quit Survey dialog negative button, it dismisses the Quit Survey dialog',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(homeWidget);
+
+      await tester.pumpAndSettle();
+      await tester.tap(nbHomeTakeSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(rbSurveyDetailStartSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(ibQuestionsQuitSurvey);
+
+      await tester.pumpAndSettle();
+      await tester.tap(tbQuestionsQuitSurveyDialogNegative);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+}
+
+Future<void> _answerAllQuestions(
+  WidgetTester tester,
+  Finder nextQuestionButton,
+  Finder submitSurveyButton,
+) async {
+  // Skip intro question
+
+  // 2nd question: Icons rating bar
+  await tester.pumpAndSettle();
+  await tester.tapAt(tester.getCenter(find.byType(AnswerWidget)));
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 3rd question: Icons rating bar
+  await tester.pumpAndSettle();
+  await tester.tapAt(tester.getCenter(find.byType(AnswerWidget)));
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 4th question: Icons rating bar
+  await tester.pumpAndSettle();
+  await tester.tapAt(tester.getCenter(find.byType(AnswerWidget)));
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 5th question: Icons rating bar
+  await tester.pumpAndSettle();
+  await tester.tapAt(tester.getCenter(find.byType(AnswerWidget)));
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 6th question: Icons rating bar
+  await tester.pumpAndSettle();
+  await tester.tapAt(tester.getCenter(find.byType(AnswerWidget)));
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 7th question: Smiley rating bar
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 8th question: Multiple choices
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 9th question: Number rating bar
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('8'));
+  await tester.pumpAndSettle();
+  await tester.tap(nextQuestionButton);
+
+  // 10th question: Text area
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextFormField), 'textArea');
+  await tester.pump(Duration(milliseconds: 100));
+  await tester.tap(nextQuestionButton);
+
+  // 11th question: Text fields
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextFormField).at(0), 'textField1');
+  await tester.pump(Duration(milliseconds: 100));
+  await tester.enterText(find.byType(TextFormField).at(1), 'textField2');
+  await tester.pump(Duration(milliseconds: 100));
+  await tester.enterText(find.byType(TextFormField).at(2), 'textField3');
+
+  // 12th question: Dropdown
+  await tester.pump(Duration(milliseconds: 100));
+  await tester.tap(nextQuestionButton);
+
+  // Skip outro question
+
+  // Submit survey
+  await tester.pumpAndSettle();
+  await tester.tap(submitSurveyButton);
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -21,5 +21,5 @@
     "numberRatingBarAnswerPositiveText": "Extremely Likely",
     "numberRatingBarAnswerNegativeText": "Not at all Likely",
     "textAreaAnswerHint": "Your thoughts",
-    "completionDefaultText": "Thanks for taking the survey."
+    "surveyCompletionDefaultText": "Thanks for taking the survey."
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -21,5 +21,5 @@
     "numberRatingBarAnswerPositiveText": "เป็นไปได้มาก",
     "numberRatingBarAnswerNegativeText": "ไม่น่าจะเป็นไปได้",
     "textAreaAnswerHint": "ความคิดเห็นของคุณ",
-    "completionDefaultText": "ขอบคุณที่สละเวลาตอบแบบสอบถาม"
+    "surveyCompletionDefaultText": "ขอบคุณที่สละเวลาตอบแบบสอบถาม"
 }

--- a/lib/navigator.dart
+++ b/lib/navigator.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:injectable/injectable.dart';
 import 'package:survey/model/survey_detail_model.dart';
 import 'package:survey/model/survey_model.dart';
-import 'package:survey/page/completion/completion_page.dart';
 import 'package:survey/page/home/home_page.dart';
 import 'package:survey/page/questions/questions_page.dart';
 import 'package:survey/page/resetpassword/reset_password_page.dart';
 import 'package:survey/page/start/start_page.dart';
+import 'package:survey/page/surveycompletion/survey_completion_page.dart';
 import 'package:survey/page/surveydetail/survey_detail_page.dart';
 
 const String _routeStart = '/';
@@ -14,7 +14,7 @@ const String routeHome = '/home';
 const String routeResetPassword = '/reset-password';
 const String routeSurveyDetail = '/survey-detail';
 const String routeQuestions = '/questions';
-const String routeCompletion = '/completion';
+const String routeSurveyCompletion = '/survey-completion';
 
 class Routes {
   static final routes = <String, WidgetBuilder>{
@@ -23,7 +23,8 @@ class Routes {
     routeResetPassword: (BuildContext context) => const ResetPasswordPage(),
     routeSurveyDetail: (BuildContext context) => const SurveyDetailPage(),
     routeQuestions: (BuildContext context) => const QuestionsPage(),
-    routeCompletion: (BuildContext context) => const CompletionPage(),
+    routeSurveyCompletion: (BuildContext context) =>
+        const SurveyCompletionPage(),
   };
 }
 
@@ -43,7 +44,7 @@ abstract class AppNavigator {
     SurveyDetailModel surveyDetail,
   );
 
-  void navigateToCompletion(BuildContext context, String? outroMessage);
+  void navigateToSurveyCompletion(BuildContext context, String? outroMessage);
 }
 
 @Injectable(as: AppNavigator)
@@ -79,10 +80,10 @@ class AppNavigatorImpl extends AppNavigator {
       );
 
   @override
-  void navigateToCompletion(BuildContext context, String? outroMessage) =>
+  void navigateToSurveyCompletion(BuildContext context, String? outroMessage) =>
       Navigator.pushReplacementNamed(
         context,
-        routeCompletion,
+        routeSurveyCompletion,
         arguments: outroMessage,
       );
 }

--- a/lib/page/questions/questions_page.dart
+++ b/lib/page/questions/questions_page.dart
@@ -8,6 +8,7 @@ import 'package:survey/gen/colors.gen.dart';
 import 'package:survey/model/question_model.dart';
 import 'package:survey/model/survey_detail_model.dart';
 import 'package:survey/navigator.dart';
+import 'package:survey/page/questions/questions_page_key.dart';
 import 'package:survey/page/questions/questions_state.dart';
 import 'package:survey/page/questions/questions_view_model.dart';
 import 'package:survey/page/questions/widget/questions_page_view_widget.dart';
@@ -95,6 +96,7 @@ class _QuestionsPageState extends ConsumerState<QuestionsPage> {
                     right: Dimens.space20,
                   ),
                   child: IconButton(
+                    key: QuestionsPageKey.ibQuestionsQuitSurvey,
                     icon: Assets.images.icClose.svg(),
                     padding: EdgeInsets.zero,
                     constraints: BoxConstraints(),
@@ -140,6 +142,7 @@ class _QuestionsPageState extends ConsumerState<QuestionsPage> {
         ),
         actions: <Widget>[
           TextButton(
+            key: QuestionsPageKey.tbQuestionsQuitSurveyDialogPositive,
             onPressed: () {
               // Close the dialog
               _appNavigator.navigateBack(context);
@@ -156,6 +159,7 @@ class _QuestionsPageState extends ConsumerState<QuestionsPage> {
             ),
           ),
           TextButton(
+            key: QuestionsPageKey.tbQuestionsQuitSurveyDialogNegative,
             onPressed: () => _appNavigator.navigateBack(context),
             child: Text(
               AppLocalizations.of(context)!

--- a/lib/page/questions/questions_page.dart
+++ b/lib/page/questions/questions_page.dart
@@ -51,7 +51,7 @@ class _QuestionsPageState extends ConsumerState<QuestionsPage> {
     ref.listen<QuestionsState>(questionsViewModelProvider, (_, state) {
       state.maybeWhen(
         submitSurveySuccess: (outroMessage) =>
-            _appNavigator.navigateToCompletion(context, outroMessage),
+            _appNavigator.navigateToSurveyCompletion(context, outroMessage),
         orElse: () {},
       );
     });

--- a/lib/page/questions/questions_page_key.dart
+++ b/lib/page/questions/questions_page_key.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class QuestionsPageKey {
+  QuestionsPageKey._();
+
+  static final ibQuestionsQuitSurvey = Key('ibQuestionsQuitSurvey');
+  static final nbQuestionsNext = Key('nbQuestionsNext');
+  static final rbQuestionsSubmitSurvey = Key('rbQuestionsSubmitSurvey');
+  static final tbQuestionsQuitSurveyDialogPositive =
+      Key('tbQuestionsQuitSurveyDialogPositive');
+  static final tbQuestionsQuitSurveyDialogNegative =
+      Key('tbQuestionsQuitSurveyDialogNegative');
+}

--- a/lib/page/questions/questions_view_model.dart
+++ b/lib/page/questions/questions_view_model.dart
@@ -30,7 +30,7 @@ class QuestionsViewModel extends StateNotifier<QuestionsState> {
     _surveyId = surveyDetail.id;
     final questions = surveyDetail.questions;
 
-    // Store text from outro question to display in the Completion screen
+    // Store text from outro question to display in the Survey Completion page
     _outroMessage = questions
         .firstWhereOrNull(
             (question) => question.displayType == DisplayType.outro)

--- a/lib/page/questions/widget/question_page_widget.dart
+++ b/lib/page/questions/widget/question_page_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:survey/model/question_model.dart';
+import 'package:survey/page/questions/questions_page_key.dart';
 import 'package:survey/page/questions/widget/answer_widget.dart';
 import 'package:survey/resource/dimens.dart';
 import 'package:survey/widget/dimmed_background_widget.dart';
@@ -71,11 +72,13 @@ class QuestionPageWidget extends StatelessWidget {
                   alignment: Alignment.centerRight,
                   child: isLastQuestion
                       ? RoundedButtonWidget(
+                          key: QuestionsPageKey.rbQuestionsSubmitSurvey,
                           buttonText:
                               AppLocalizations.of(context)!.questionsSubmit,
                           onPressed: () => onSubmitSurveyPressed.call(),
                         )
                       : NextButtonWidget(
+                          key: QuestionsPageKey.nbQuestionsNext,
                           onPressed: () => onNextQuestionPressed.call(),
                         ),
                 ),

--- a/lib/page/surveycompletion/survey_completion_page.dart
+++ b/lib/page/surveycompletion/survey_completion_page.dart
@@ -9,16 +9,16 @@ import 'package:survey/gen/colors.gen.dart';
 import 'package:survey/navigator.dart';
 import 'package:survey/resource/dimens.dart';
 
-const _completionPageDurationInSecond = 2;
+const _surveyCompletionPageDurationInSecond = 2;
 
-class CompletionPage extends StatefulWidget {
-  const CompletionPage({super.key});
+class SurveyCompletionPage extends StatefulWidget {
+  const SurveyCompletionPage({super.key});
 
   @override
-  State<CompletionPage> createState() => _CompletionPageState();
+  State<SurveyCompletionPage> createState() => _SurveyCompletionPageState();
 }
 
-class _CompletionPageState extends State<CompletionPage>
+class _SurveyCompletionPageState extends State<SurveyCompletionPage>
     with TickerProviderStateMixin {
   final _appNavigator = getIt.get<AppNavigator>();
 
@@ -27,7 +27,7 @@ class _CompletionPageState extends State<CompletionPage>
         ..addStatusListener((status) {
           if (status == AnimationStatus.completed) {
             // Wait for 2 seconds after animation is completed before navigating back to the Home screen
-            Timer(Duration(seconds: _completionPageDurationInSecond), () {
+            Timer(Duration(seconds: _surveyCompletionPageDurationInSecond), () {
               _appNavigator.navigateBack(context);
             });
           }
@@ -46,8 +46,8 @@ class _CompletionPageState extends State<CompletionPage>
           const Expanded(child: const SizedBox.shrink()),
           Lottie.asset(
             Assets.lotties.surveyCompleted,
-            width: Dimens.completionSurveyCompletedLottieSize,
-            height: Dimens.completionSurveyCompletedLottieSize,
+            width: Dimens.surveyCompletionSurveyCompletedLottieSize,
+            height: Dimens.surveyCompletionSurveyCompletedLottieSize,
             fit: BoxFit.fill,
             controller: _animationController,
             onLoaded: (composition) {
@@ -57,7 +57,8 @@ class _CompletionPageState extends State<CompletionPage>
             },
           ),
           Text(
-            outroMessage ?? AppLocalizations.of(context)!.completionDefaultText,
+            outroMessage ??
+                AppLocalizations.of(context)!.surveyCompletionDefaultText,
             style: Theme.of(context).textTheme.headline6,
             textAlign: TextAlign.center,
             maxLines: 3,

--- a/lib/resource/dimens.dart
+++ b/lib/resource/dimens.dart
@@ -53,5 +53,5 @@ class Dimens {
   static const double questionsMultipleChoicesAnswerCheckboxBorderWidth = 2;
   static const double questionsMultipleChoicesAnswerCheckboxIconSize = 18;
 
-  static const double completionSurveyCompletedLottieSize = 200;
+  static const double surveyCompletionSurveyCompletedLottieSize = 200;
 }


### PR DESCRIPTION
#111, #112

## What happened 👀

Write integration tests for both Questions and Completion pages inside one test file
- [x] Create and bind keys to each widget
- [x] Create the test file and write integration test functions
- [x] Refactor other integration tests code
- [x] Rename Survey Completion page

## Insight 📝

- Since we always have to start from the Home page, I think grouping it into one test file can reduce some repetitive code
- We can use the below command to run this test on an emulator:
```
fvm flutter drive --driver=integration_test_driver/integration_test_driver.dart --flavor staging --target=integration_test/take_survey_flow_test.dart
```

## Proof Of Work 📹

All tests passed!

🎥 https://drive.google.com/file/d/1WdRkal8kLKLkg8eVIE30q_rSSjIg10i5/view?usp=share_link
